### PR TITLE
Generating statement-oriented syntax in backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,5 @@ notifications:
 language: node_js
 node_js:
   - "lts/*"
-install:
-  - npm install
 script:
-  - npm run lint || true # informational only, ignore errors
-  - npm run test-backend
-  - npm run fetch-kernel
-  - npm run render-kernel
-  - npm run render-kernel async
-  - npm run test-kernel || true # 1 test fails due to stack overflow in sync mode
-  - npm run test-kernel async
-  - npm run test-frontend
+  - echo "Do nothing"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,14 @@ notifications:
 language: node_js
 node_js:
   - "lts/*"
+install:
+  - npm install
 script:
-  - echo "Do nothing"
+  - npm run lint || true # informational only, ignore errors
+  - npm run test-backend
+  - npm run fetch-kernel
+  - npm run render-kernel
+  - npm run render-kernel async
+  - npm run test-kernel || true # 1 test fails due to stack overflow in sync mode
+  - npm run test-kernel async
+  - npm run test-frontend

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -16,13 +16,13 @@ const Block = (...body) => ({ type: 'BlockStatement', body });
 const Call = (callee, args, async = false) => (async ? Await : id)({ type: 'CallExpression', callee, arguments: args });
 const Catch = (param, body) => ({ type: 'CatchClause', param, body });
 const Class = (id, superClass, body) => ({ type: 'ClassExpression', id, superClass, body: { type: 'ClassBody', body } });
+const Conditional = (test, consequent, alternate) => ({ type: 'ConditionalExpression', test, consequent, alternate });
 const Const = (id, init) => Local('const', id, init);
 const Debugger = { type: 'DebuggerStatement' };
-const Do = (...expressions) => ({ type: 'SequenceExpression', expressions });
 const RawIdentifier = name => ({ type: 'Identifier', name });
 const Generator = body => ({ type: 'FunctionExpression', generator: true, body }); // TODO: async? static?
 const Identifier = name => RawIdentifier(escapeName(name));
-const If = (test, consequent, alternate) => ({ type: 'ConditionalExpression', test, consequent, alternate });
+const If = (test, consequent, alternate) => ({ type: 'IfStatement', test, consequent, alternate });
 const Iife = (body, async = false) => Call(Arrow([], body, async), [], async);
 const Let = (id, init) => Local('let', id, init);
 const Literal = value => ({ type: 'Literal', value });
@@ -38,6 +38,7 @@ const NewTarget = { type: 'MetaProperty', meta: RawIdentifier('new'), property: 
 const Procedure = body => ({ type: 'FunctionExpression', body }); // TODO: async? static?
 const Program = body => ({ type: 'Program', body });
 const Return = argument => ({ type: 'ReturnStatement', argument });
+const Sequence = (...expressions) => ({ type: 'SequenceExpression', expressions });
 const Slot = (static, kind, key, value) => ({
   type: 'MethodExpression', key, computed: key.type !== 'Identifier', kind, static, value
 });
@@ -59,8 +60,8 @@ const adorn = (tag, raw) => TaggedTemplate(tag, TemplateLiteral([TemplateElement
 const ann = (dataType, ast) => Object.assign(ast, { dataType });
 
 module.exports = {
-  Arrow, Assign, Await, Binary, Block, Call, Catch, Class, Const, Debugger, Do, Generator, Identifier, If, Iife, Let,
-  Literal, Local, Member, New, NewTarget, Procedure, Program, RawIdentifier, Return, Slot, Spread, Statement, Super,
-  TaggedTemplate, TemplateElement, TemplateLiteral, This, Try, Unary, Var, Vector, Yield, YieldMany,
+  Arrow, Assign, Await, Binary, Block, Call, Catch, Class, Conditional, Const, Debugger, Generator, Identifier, If,
+  Iife, Let, Literal, Local, Member, New, NewTarget, Procedure, Program, RawIdentifier, Return, Sequence, Slot, Spread,
+  Statement, Super, TaggedTemplate, TemplateElement, TemplateLiteral, This, Try, Unary, Var, Vector, Yield, YieldMany,
   adorn, ann, generate
 };

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -10,6 +10,7 @@ const validName = name => validCharactersRegex.test(name);
 
 const Arrow = (params, body, async = false) => ({ type: 'ArrowFunctionExpression', async, params, body, });
 const Assign = (left, right) => ({ type: 'AssignmentExpression', operator: '=', left, right });
+const Async = ast => ({ ...ast, async: true });
 const Await = argument => ({ type: 'AwaitExpression', argument });
 const Binary = (operator, left, right) => ({ type: 'BinaryExpression', operator, left, right });
 const Block = (...body) => ({ type: 'BlockStatement', body });
@@ -20,7 +21,7 @@ const Conditional = (test, consequent, alternate) => ({ type: 'ConditionalExpres
 const Const = (id, init) => Local('const', id, init);
 const Debugger = { type: 'DebuggerStatement' };
 const RawIdentifier = name => ({ type: 'Identifier', name });
-const Generator = body => ({ type: 'FunctionExpression', generator: true, body }); // TODO: async? static?
+const Generator = body => ({ type: 'FunctionExpression', generator: true, body });
 const Identifier = (name, suffix = '') => RawIdentifier(escapeName(name) + suffix);
 const If = (test, consequent, alternate) => ({ type: 'IfStatement', test, consequent, alternate });
 const Iife = (body, async = false) => Call(Arrow([], body, async), [], async);
@@ -35,7 +36,7 @@ const Member = (object, property) =>
     : { type: 'MemberExpression', object, property, computed: property.type !== 'Identifier' };
 const New = (callee, args) => ({ type: 'NewExpression', callee, arguments: args });
 const NewTarget = { type: 'MetaProperty', meta: RawIdentifier('new'), property: RawIdentifier('target') };
-const Procedure = body => ({ type: 'FunctionExpression', body }); // TODO: async? static?
+const Procedure = body => ({ type: 'FunctionExpression', body });
 const Program = body => ({ type: 'Program', body });
 const Return = argument => ({ type: 'ReturnStatement', argument });
 const Sequence = (...expressions) => ({ type: 'SequenceExpression', expressions });
@@ -44,6 +45,7 @@ const Slot = (static, kind, key, value) => ({
 });
 const Spread = argument => ({ type: 'SpreadElement', argument });
 const Statement = expression => ({ type: 'ExpressionStatement', expression });
+const Static = ast => ({ ...ast, static: true });
 const Super = args => ({ type: "Super", arguments: args });
 const TaggedTemplate = (tag, quasi) => ({ type: 'TaggedTemplateExpression', tag, quasi });
 const TemplateElement = raw => ({ type: 'TemplateElement', value: { raw } });
@@ -60,8 +62,9 @@ const adorn = (tag, raw) => TaggedTemplate(tag, TemplateLiteral([TemplateElement
 const ann = (dataType, ast) => Object.assign(ast, { dataType });
 
 module.exports = {
-  Arrow, Assign, Await, Binary, Block, Call, Catch, Class, Conditional, Const, Debugger, Generator, Identifier, If,
-  Iife, Let, Literal, Local, Member, New, NewTarget, Procedure, Program, RawIdentifier, Return, Sequence, Slot, Spread,
-  Statement, Super, TaggedTemplate, TemplateElement, TemplateLiteral, This, Try, Unary, Var, Vector, Yield, YieldMany,
+  Arrow, Assign, Async, Await, Binary, Block, Call, Catch, Class, Conditional, Const, Debugger, Generator, Identifier,
+  If, Iife, Let, Literal, Local, Member, New, NewTarget, Procedure, Program, RawIdentifier, Return, Sequence, Slot,
+  Spread, Statement, Static, Super, TaggedTemplate, TemplateElement, TemplateLiteral, This, Try, Unary, Var, Vector,
+  Yield, YieldMany,
   adorn, ann, generate
 };

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -24,7 +24,6 @@ const RawIdentifier = name => ({ type: 'Identifier', name });
 const Generator = body => ({ type: 'FunctionExpression', generator: true, body });
 const Identifier = (name, suffix = '') => RawIdentifier(escapeName(name) + suffix);
 const If = (test, consequent, alternate) => ({ type: 'IfStatement', test, consequent, alternate });
-const Iife = (body, async = false) => Call(Arrow([], body, async), [], async);
 const Let = (id, init) => Local('let', id, init);
 const Literal = value => ({ type: 'Literal', value });
 const Local = (kind, id, init) => ({
@@ -62,9 +61,9 @@ const adorn = (tag, raw) => TaggedTemplate(tag, TemplateLiteral([TemplateElement
 const ann = (dataType, ast) => Object.assign(ast, { dataType });
 
 module.exports = {
-  Arrow, Assign, Async, Await, Binary, Block, Call, Catch, Class, Conditional, Const, Debugger, Generator, Identifier,
-  If, Iife, Let, Literal, Local, Member, New, NewTarget, Procedure, Program, RawIdentifier, Return, Sequence, Slot,
-  Spread, Statement, Static, Super, TaggedTemplate, TemplateElement, TemplateLiteral, This, Try, Unary, Var, Vector,
-  Yield, YieldMany,
+  Arrow, Assign, Async, Await, Binary, Block, Call, Catch, Class, Conditional, Const, Debugger,
+  Generator, Identifier, If, Let, Literal, Local, Member, New, NewTarget, Procedure, Program,
+  RawIdentifier, Return, Sequence, Slot, Spread, Statement, Static, Super, TaggedTemplate,
+  TemplateElement, TemplateLiteral, This, Try, Unary, Var, Vector, Yield, YieldMany,
   adorn, ann, generate
 };

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -21,7 +21,7 @@ const Const = (id, init) => Local('const', id, init);
 const Debugger = { type: 'DebuggerStatement' };
 const RawIdentifier = name => ({ type: 'Identifier', name });
 const Generator = body => ({ type: 'FunctionExpression', generator: true, body }); // TODO: async? static?
-const Identifier = name => RawIdentifier(escapeName(name));
+const Identifier = (name, suffix = '') => RawIdentifier(escapeName(name) + suffix);
 const If = (test, consequent, alternate) => ({ type: 'IfStatement', test, consequent, alternate });
 const Iife = (body, async = false) => Call(Arrow([], body, async), [], async);
 const Let = (id, init) => Local('let', id, init);

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -194,7 +194,6 @@ const fab = (expression, statements = []) => new Fabrication(expression, stateme
 //       functions like assemble are for composing and mapping through Fabs
 const assemble = (combine, ...fabs) => fab(combine(...fabs.map(x => x.expression)), flatMap(fabs, x => x.statements));
 const complete = (context, ast) => Call$(context.async ? 'u' : 't', [ast], context.async);
-const completeOrReturn = (context, ast) => context.head ? complete(context, ast) : ast;
 const completeOrBounce = (context, fAst, argsAsts) =>
   context.head ? complete(context, Call(fAst, argsAsts)) : Call$('b', [fAst, ...argsAsts]);
 const recognisors = {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -3,7 +3,7 @@ const {
   Arrow, Assign, Binary, Block, Call, Catch, Conditional, Const, Identifier, If, Iife,
   Let, Literal, Member, RawIdentifier, Return, Sequence, Statement, Try, Unary, Vector
 } = require('./ast');
-const { AsyncFunction, butLast, last, concat, flatMap, produce, raise, s } = require('./utils');
+const { AsyncFunction, butLast, last, flatMap, produce, raise, s } = require('./utils');
 
 const Cons = class {
   constructor(head, tail) {
@@ -143,9 +143,15 @@ const Member$ = name => Member(RawIdentifier('$'), RawIdentifier(name));
 const Member$f = name => Member(Member$('f'), Literal(name));
 const Call$ = (name, args, async = false) => Call(Member$(name), args, async);
 const Call$f = (name, args) => Call(Member$f(name), args);
-const cast = (dataType, ast) => dataType !== ast.dataType ? Object.assign(Call$('as' + dataType, [ast]), { dataType }) : ast;
+const cast = (dataType, ast) =>
+  ast instanceof Fabrication
+    ? fab(cast(dataType, ast.expression), ast.statements)
+    : (dataType !== ast.dataType ? Object.assign(Call$('as' + dataType, [ast]), { dataType }) : ast);
 // TODO: clean this up
-const uncast = ast => ast instanceof Fabrication ? fab(uncast(ast.expression), ast.statements) : ast.dataType === 'JsBool' ? cast('ShenBool', ast) : ast;
+const uncast = ast =>
+  ast instanceof Fabrication
+    ? fab(uncast(ast.expression), ast.statements)
+    : (ast.dataType === 'JsBool' ? cast('ShenBool', ast) : ast);
 const isForm = (expr, lead, length) => isNeArray(expr) && expr[0] === symbolOf(lead) && (!length || expr.length === length);
 const isInline = (context, expr) => isNeArray(expr) && isSymbol(expr[0]) && context.primitives.hasOwnProperty(nameOf(expr[0])) && context.primitives[nameOf(expr[0])].length === expr.length - 1;
 const idle = id => ann('Symbol', adorn(Member$('s'), nameOf(id)));
@@ -158,18 +164,20 @@ const completeOrBounce = (context, fAst, argsAsts) =>
 const symbolKey = ast => Call$('nameOf', [cast('Symbol', ast)]); // TODO: no longer optimizes literal symbols
 const buildIf = (context, expr) => {
   if (expr[1] === shenTrue) {
-    return fab(uncast(build(context, expr[2])));
+    return uncast(build(context, expr[2]));
   }
-  const [condFab, trueFab, falseFab] = expr.slice(1).map(x => build(context, x));
+  const condFab = cast('JsBool', build(context.now(), expr[1]));
+  const trueFab = build(context, expr[2]);
+  const falseFab = build(context, expr[3]);
   if (trueFab.anyStatements() || falseFab.anyStatements()) {
     const [resultId, output] = placeholder();
     return fab(
       resultId, [
         Let(resultId),
         If(
-          cast('JsBool', condFab.expression),
-          trueFab.anyStatements()  ? Block(...trueFab.statements,  output(trueFab))  : output(trueFab),
-          falseFab.anyStatements() ? Block(...falseFab.statements, output(falseFab)) : output(falseFab))]);
+          condFab.expression,
+          trueFab.anyStatements()  ? Block(...trueFab.statements,  output(trueFab.expression))  : output(trueFab.expression),
+          falseFab.anyStatements() ? Block(...falseFab.statements, output(falseFab.expression)) : output(falseFab.expression))]);
   }
   return fab(Conditional(condFab.expression, trueFab.expression, falseFab.expression), condFab.statements);
 };
@@ -183,20 +191,26 @@ const buildDo = (context, [_do, ...exprs]) => {
   const exprFabs = exprs.map(x => uncast(build(context, x)));
   if (exprFabs.some(x => x.anyStatements())) {
     return fab(
-      uncast(last(exprFabs).expression),
-      concat(
-        flatMap(butLast(exprFabs), x => concat(x.statements, Statement(x.expression))),
-        last(exprFabs).statements));
+      uncast(last(exprFabs).expression), [
+        ...flatMap(butLast(exprFabs), x => [...x.statements, Statement(x.expression)]),
+        last(exprFabs).statements]);
   }
   return fab(Sequence(...exprFabs.map(x => x.expression)));
 };
 const buildLet = (context, [_let, symbol, binding, body]) => {
   const bindingFab = uncast(build(context.now(), binding));
   const bodyFab = uncast(build(context.add([asSymbol(symbol)]), body));
-  const constStmt = Const(Identifier(nameOf(symbol)), bindingFab.expression);
+  const symbolId = Identifier(nameOf(symbol));
+  const constStmt = Const(symbolId, bindingFab.expression);
+  if (context.has(symbol)) {
+    const [resultId, output] = placeholder();
+    return fab(resultId, [
+      Let(resultId),
+      Block(...bindingFab.statements, constStmt, ...bodyFab.statements, output(bodyFab.expression))]);
+  }
   return fab(bodyFab.expression, [...bindingFab.statements, constStmt, ...bodyFab.statements]);
 };
-const buildHandler = (context, handler) => {
+const buildHandler = (context, handler, output) => {
   if (isForm(handler, 'lambda', 3)) {
     const handlerFab = uncast(build(context.add([handler[1]]), handler[2]));
     return Catch(Identifier(nameOf(handler[1])), Block(...handlerFab.statements, output(handlerFab.expression)));
@@ -212,8 +226,8 @@ const buildTrap = (context, [_trap, body, handler]) => {
   return fab(resultId, [
     Let(resultId),
     Try(
-      Block(...bodyFab.statements, output(bodyFab)),
-      buildHandler(context, handler))]);
+      Block(...bodyFab.statements, output(bodyFab.expression)),
+      buildHandler(context, handler, output))]);
 };
 const buildLambda = (context, params, body) => {
   const bodyFab = uncast(build(context.later().add(params.map(asSymbol)), body));
@@ -224,14 +238,16 @@ const buildLambda = (context, params, body) => {
 };
 const buildDefun = (context, [_defun, symbol, params, body]) =>
   // TODO: in ignore situation, the idle symbol and be dropped
-  fab(Sequence(Assign(Member$f(nameOf(symbol)), buildLambda(context.clear(), params, body)), idle(symbol)));
+  // NOTE: buildLambda should never return a fab with statements,
+  //       factor out code to emit JsExpr instead of Fab to another function?
+  fab(Sequence(Assign(Member$f(nameOf(symbol)), buildLambda(context.clear(), params, body).expression), idle(symbol)));
 const buildCons = (context, expr) =>
   assemble(
-    xs => ann('Cons', Call$('consFromArray', [Vector(xs)])),
-    produce(x => isForm(x, 'cons', 3), x => uncast(build(context.now(), x[1])), x => x[2], expr));
+    (...xs) => ann('Cons', Call$('consFromArray', [Vector(xs)])),
+    ...produce(x => isForm(x, 'cons', 3), x => uncast(build(context.now(), x[1])), x => x[2], expr));
 const buildSet = (context, [_set, symbol, value]) =>
   assemble(
-    (sym, val) => Assign(Member(Member$f('symbols'), symbolKey(sym)), val),
+    (sym, val) => Assign(Member(Member$('symbols'), symbolKey(sym)), val),
     build(context.now(), symbol),
     uncast(build(context.now(), value)));
 const buildValue = (context, [_value, symbol]) =>
@@ -241,13 +257,13 @@ const buildValue = (context, [_value, symbol]) =>
 const buildInline = (context, [fExpr, ...argExprs]) =>
   assemble(
     context.primitives[nameOf(fExpr)],
-    argExprs.map(x => build(context.now(), x)));
+    ...argExprs.map(x => build(context.now(), x)));
 const buildApp = (context, [fExpr, ...argExprs]) =>
   assemble(
     (f, ...args) => completeOrBounce(context, f, args),
-    context.has(fExpr) ? Identifier(nameOf(fExpr)) :
+    context.has(fExpr) ? fab(Identifier(nameOf(fExpr))) :
     isArray(fExpr)     ? build(context.now(), fExpr) :
-    isSymbol(fExpr)    ? Member$f(nameOf(fExpr)) :
+    isSymbol(fExpr)    ? fab(Member$f(nameOf(fExpr))) :
     raise('not a valid application form'),
     ...argExprs.map(x => uncast(build(context.now(), x))));
 const build = (context, expr) =>
@@ -406,8 +422,14 @@ module.exports = (options = {}) => {
     asStream, asInStream, asOutStream, asNumber, asString, asSymbol, asCons, asArray, asError, asFunction,
     symbolOf, nameOf, valueOf, show, equate, raise, fun, bounce, settle, future, compile,
     f: functions, s, b: bounce, t: settle, u: future, async: options.async
+
+    // TODO: remove these, they're here for temp debugging
+    , build, context, cast, uncast, generate
   };
   const Func = context.async ? AsyncFunction : Function;
-  functions['eval-kl'] = fun($.evalKl = expr => Func('$', generate(Return(compile(valueToArrayTree(expr)))))($));
+  functions['eval-kl'] = fun($.evalKl = expr => {
+    const exprFab = compile(valueToArrayTree(expr));
+    return Func('$', generate(Block(...exprFab.statements, Return(exprFab.expression))))($);
+  });
   return $;
 };

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -1,7 +1,7 @@
 const {
   adorn, ann, generate,
-  Arrow, Assign, Binary, Block, Call, Catch, Conditional, Const, Identifier, If, Iife,
-  Let, Literal, Member, RawIdentifier, Return, Sequence, Statement, Try, Unary, Vector
+  Arrow, Assign, Binary, Block, Call, Catch, Conditional, Const, Identifier, If, Let,
+  Literal, Member, RawIdentifier, Return, Sequence, Statement, Try, Unary, Vector
 } = require('./ast');
 const { AsyncFunction, butLast, last, flatMap, produce, produceState, raise, s } = require('./utils');
 
@@ -227,6 +227,7 @@ const buildIf = (context, [_if, condition, ifTrue, ifFalse]) => {
     const [resultId, output] = placeholder();
     return fab(
       resultId, [
+        ...condFab.statements,
         Let(resultId),
         If(
           condFab.expression,
@@ -263,7 +264,8 @@ const buildLet = (context, [_let, symbol, binding, body]) => {
   const meta = conflict ? { dataType, alt: symbolId } : { dataType };
   const bodyFab = uncast(build(context.add([asSymbol(symbol), meta]), body));
   const constStmt = Const(symbolId, bindingFab.expression);
-  if (!conflict && context.has(symbol)) {
+  //if (!conflict && context.has(symbol)) {
+    // FIXME: there's also a problem when there are 2 adjacent let's with the same name
     // TODO: additional block can be avoided if there's already a block between here and outer variable scope
     //       this can be tracked in locals Map in Context. Entering a new block would switch a property on
     //       every local to true
@@ -271,8 +273,8 @@ const buildLet = (context, [_let, symbol, binding, body]) => {
     return fab(resultId, [
       Let(resultId),
       Block(...bindingFab.statements, constStmt, ...bodyFab.statements, output(bodyFab.expression))]);
-  }
-  return fab(bodyFab.expression, [...bindingFab.statements, constStmt, ...bodyFab.statements]);
+  //}
+  //return fab(bodyFab.expression, [...bindingFab.statements, constStmt, ...bodyFab.statements]);
 };
 const buildHandler = (context, handler, output) => {
   if (isForm(handler, 'lambda', 3)) {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -319,7 +319,7 @@ const buildCons = (context, expr) => {
       ...[...result, state].map(x => uncast(build(context.now(), x))));
 };
 const buildSet = (context, [_set, symbol, value]) =>
-  isSymbol(symbol) ?
+  isSymbol(symbol) && !context.has(symbol) ?
     assemble(
       val => Assign(Member(Member$('symbols'), Literal(nameOf(symbol))), val),
       uncast(build(context.now(), value))) :
@@ -328,7 +328,7 @@ const buildSet = (context, [_set, symbol, value]) =>
       uncast(build(context.now(), symbol)),
       uncast(build(context.now(), value)));
 const buildValue = (context, [_value, symbol]) =>
-  isSymbol(symbol) ?
+  isSymbol(symbol) && !context.has(symbol) ?
     fab(Call$('valueOf', [Literal(nameOf(symbol))])) :
     assemble(
       sym => Call$('valueOf', [Call$('nameOf', [cast('Symbol', sym)])]),

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -32,11 +32,16 @@ const Context = class {
   later()       { return this.with({ head: false }); }
 
   // TODO: these won't be necessary for the initial solution?
+  // TODO: instead of "situations", Context could carry a continuation
+  //       that constructs expressions in tail position instead of
+  //       always assinging to a result variable
+  // NOTE: returned ast will need meta indicating if continuation was applied
+  //       or result is still an expression
   evaluated()   { return this.with({ situation: 'evaluated' }); }
   passed()      { return this.with({ situation: 'passed' }); } // might not be necessary/redundant with evaluated
-  returned()    { return this.with({ situation: 'returned' }); }
-  assigned()    { return this.with({ situation: 'assigned' }); }
-  ignored()     { return this.with({ situation: 'ignored' }); }
+  returned()    { return this.with({ situation: 'returned' }); } // continuation: x => Return(x)
+  assigned()    { return this.with({ situation: 'assigned' }); } // continuation: x => Assign(tempId, x)
+  ignored()     { return this.with({ situation: 'ignored' }); }  // continuation: x => Statement(x)
 
   clear()       { return this.with({ locals: new Set() }); }
   add(locals)   { return this.with({ locals: new Set([...this.locals, ...locals]) }); }
@@ -45,7 +50,7 @@ const Context = class {
 
 const Fabrication = class {
   constructor(expression, statements) {
-    this.expression = expression;
+    this.expression = expression; // TODO: shorter names!
     this.statements = statements;
     Object.freeze(this);
   }
@@ -104,7 +109,7 @@ const equate = (x, y) =>
   || isArray(x)  && isArray(y)  && x.length === y.length  && x.every((v, i) => equate(v, y[i]))
   || isObject(x) && isObject(y) && equateType(x, y)       && Object.keys(x).every(k => equate(x[k], y[k]));
 
-// TODO: use Function.bind for partial applications
+// TODO: use Function.bind for partial applications?
 const funSync = (f, arity) =>
   (...args) =>
     args.length === arity ? f(...args) :
@@ -132,6 +137,9 @@ const future = async x => {
   return x;
 };
 
+// TODO: this can be on the Context instead of being global
+//       temp vars only need to be unique per scope
+// NOTE: this could also cut down on the size of the identifiers
 let counter = 0;
 const tempId = () => RawIdentifier(`R${counter++}$`);
 const placeholder = () => {
@@ -153,7 +161,11 @@ const uncast = ast =>
     ? fab(uncast(ast.expression), ast.statements)
     : (ast.dataType === 'JsBool' ? cast('ShenBool', ast) : ast);
 const isForm = (expr, lead, length) => isNeArray(expr) && expr[0] === symbolOf(lead) && (!length || expr.length === length);
-const isInline = (context, expr) => isNeArray(expr) && isSymbol(expr[0]) && context.primitives.hasOwnProperty(nameOf(expr[0])) && context.primitives[nameOf(expr[0])].length === expr.length - 1;
+const isInline = (context, expr) =>
+  isNeArray(expr) &&
+  isSymbol(expr[0]) &&
+  context.primitives.hasOwnProperty(nameOf(expr[0])) &&
+  context.primitives[nameOf(expr[0])].length === expr.length - 1;
 const appears = (symbol, expr) =>
   isForm(expr, 'let', 4)    ? appears(symbol, expr[2]) || (symbol !== expr[1] && appears(symbol, expr[3])) :
   isForm(expr, 'lambda', 3) ? symbol !== expr[1] && appears(symbol, expr[2]) :
@@ -167,14 +179,13 @@ const complete = (context, ast) => Call$(context.async ? 'u' : 't', [ast], conte
 const completeOrReturn = (context, ast) => context.head ? complete(context, ast) : ast;
 const completeOrBounce = (context, fAst, argsAsts) =>
   context.head ? complete(context, Call(fAst, argsAsts)) : Call$('b', [fAst, ...argsAsts]);
-const symbolKey = ast => Call$('nameOf', [cast('Symbol', ast)]); // TODO: no longer optimizes literal symbols
-const buildIf = (context, expr) => {
-  if (expr[1] === shenTrue) {
-    return uncast(build(context, expr[2]));
+const buildIf = (context, [_if, condition, ifTrue, ifFalse]) => {
+  if (condition === shenTrue) {
+    return uncast(build(context, ifTrue));
   }
-  const condFab = cast('JsBool', build(context.now(), expr[1]));
-  const trueFab = uncast(build(context, expr[2]));
-  const falseFab = uncast(build(context, expr[3]));
+  const condFab = cast('JsBool', build(context.now(), condition));
+  const trueFab = uncast(build(context, ifTrue));
+  const falseFab = uncast(build(context, ifFalse));
   if (trueFab.anyStatements() || falseFab.anyStatements()) {
     const [resultId, output] = placeholder();
     return fab(
@@ -187,13 +198,11 @@ const buildIf = (context, expr) => {
   }
   return fab(Conditional(condFab.expression, trueFab.expression, falseFab.expression), condFab.statements);
 };
-const buildCond = (context, expr) =>
-  // TODO: does this uncast do anything? should there be uncasts on the branches of if instead?
-  uncast(build(context, expr.slice(1).reduceRight(
+const buildCond = (context, [_cond, ...clauses]) =>
+  build(context, clauses.reduceRight(
     (alternate, [test, consequent]) => [s`if`, test, consequent, alternate],
-    [s`simple-error`, 'no condition was true'])));
+    [s`simple-error`, 'no condition was true']));
 const buildDo = (context, [_do, ...exprs]) => {
-  // TODO: flatten do's ?
   const exprFabs = [...butLast(exprs).map(x => uncast(build(context.now(), x))), uncast(build(context, last(exprs)))];
   if (exprFabs.some(x => x.anyStatements())) {
     return fab(last(exprFabs).expression, [
@@ -207,8 +216,7 @@ const buildLet = (context, [_let, symbol, binding, body]) => {
   //       initialize in terms of pre-existing variable
   // TODO: if symbol does not appear in body, can convert (let X Y Z) to (do Y Z)
   if (!appears(symbol, body)) {
-    // TODO: unnecessary uncast?
-    return uncast(build(context, [s`do`, binding, body]));
+    return build(context, [s`do`, binding, body]);
   }
   // TODO: if symbol appears in binding, need temp variable to construct init value (THIS DOESN"T WORK)
   //       can later be improved with variable renaming?
@@ -218,6 +226,7 @@ const buildLet = (context, [_let, symbol, binding, body]) => {
   const constStmt = Const(symbolId, bindingFab.expression);
   if (context.has(symbol)) {
     // TODO: additional block can be avoided if there's already a block between here and outer variable scope
+    //       this can be tracked in locals Map in Context
     const [resultId, output] = placeholder();
     return fab(resultId, [
       Let(resultId),
@@ -258,23 +267,33 @@ const buildDefun = (context, [_defun, symbol, params, body]) =>
   fab(Sequence(Assign(Member$f(nameOf(symbol)), buildLambda(context.clear(), params, body).expression), idle(symbol)));
 const buildCons = (context, expr) => {
   const { result, state } = produceState(x => isForm(x, 'cons', 3), x => x[1], x => x[2], expr);
-  return assemble(
-    (...xs) => ann('Cons', Call$('consFromArray', [Vector(butLast(xs)), last(xs)])),
-    ...[...result, state].map(x => uncast(build(context.now(), x))));
+  return isEArray(state) || state === null ?
+    assemble(
+      (...xs) => ann('Cons', Call$('consFromArray', [Vector(xs)])),
+      ...result.map(x => uncast(build(context.now(), x)))) :
+    assemble(
+      (...xs) => ann('Cons', Call$('consFromArray', [Vector(butLast(xs)), last(xs)])),
+      ...[...result, state].map(x => uncast(build(context.now(), x))));
 };
 const buildSet = (context, [_set, symbol, value]) =>
-  assemble(
-    (sym, val) => Assign(Member(Member$('symbols'), symbolKey(sym)), val),
-    uncast(build(context.now(), symbol)),
-    uncast(build(context.now(), value)));
+  isSymbol(symbol) ?
+    assemble(
+      val => Assign(Member(Member$('symbols'), Literal(nameOf(symbol))), val),
+      uncast(build(context.now(), value))) :
+    assemble(
+      (sym, val) => Assign(Member(Member$('symbols'), Call$('nameOf', [cast('Symbol', sym)])), val),
+      uncast(build(context.now(), symbol)),
+      uncast(build(context.now(), value)));
 const buildValue = (context, [_value, symbol]) =>
-  assemble(
-    sym => Call$('valueOf', [symbolKey(sym)]),
-    uncast(build(context.now(), symbol)));
+  isSymbol(symbol) ?
+    fab(Call$('valueOf', [Literal(nameOf(symbol))])) :
+    assemble(
+      sym => Call$('valueOf', [Call$('nameOf', [cast('Symbol', sym)])]),
+      uncast(build(context.now(), symbol)));
 const buildInline = (context, [fExpr, ...argExprs]) =>
   assemble(
     context.primitives[nameOf(fExpr)],
-    ...argExprs.map(x => uncast(build(context.now(), x)))); // TODO: remove this uncast, individual prims handle that
+    ...argExprs.map(x => build(context.now(), x)));
 const buildApp = (context, [fExpr, ...argExprs]) =>
   assemble(
     (f, ...args) => completeOrBounce(context, f, args),

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -1,9 +1,9 @@
 const {
   adorn, ann, generate,
-  Arrow, Assign, Binary, Block, Call, Catch, Conditional, Identifier, If, Iife,
-  Literal, Member, RawIdentifier, Return, Sequence, Statement, Try, Unary, Vector
+  Arrow, Assign, Binary, Block, Call, Catch, Conditional, Const, Identifier, If, Iife,
+  Let, Literal, Member, RawIdentifier, Return, Sequence, Statement, Try, Unary, Vector
 } = require('./ast');
-const { AsyncFunction, flatMap, produce, raise, s } = require('./utils');
+const { AsyncFunction, butLast, last, concat, flatMap, produce, raise, s } = require('./utils');
 
 const Cons = class {
   constructor(head, tail) {
@@ -140,14 +140,14 @@ const Member$f = name => Member(Member$('f'), Literal(name));
 const Call$ = (name, args, async = false) => Call(Member$(name), args, async);
 const Call$f = (name, args) => Call(Member$f(name), args);
 const cast = (dataType, ast) => dataType !== ast.dataType ? Object.assign(Call$('as' + dataType, [ast]), { dataType }) : ast;
-const uncast = ast => ast.dataType === 'JsBool' ? cast('ShenBool', ast) : ast;
+// TODO: clean this up
+const uncast = ast => ast instanceof Fabrication ? fab(uncast(ast.expression), ast.statements) : ast.dataType === 'JsBool' ? cast('ShenBool', ast) : ast;
 const isForm = (expr, lead, length) => isNeArray(expr) && expr[0] === symbolOf(lead) && (!length || expr.length === length);
 const isConsForm = (expr, depth) => depth === 0 || isForm(expr, 'cons', 3) && isConsForm(expr[2], depth - 1);
 const isPrimitiveApplication = (context, expr) => isNeArray(expr) && isSymbol(expr[0]) && context.primitives.hasOwnProperty(nameOf(expr[0])) && context.primitives[nameOf(expr[0])].length === expr.length - 1;
 const idle = id => ann('Symbol', adorn(Member$('s'), nameOf(id)));
 const fab = (expression, statements = []) => new Fabrication(expression, statements);
-const asm = (combine, ...constructs) =>
-  fab(combine(...constructs.map(x => x.expression)), flatMap(constructs, x => x.statements));
+const assemble = (combine, ...fabs) => fab(combine(...fabs.map(x => x.expression)), flatMap(fabs, x => x.statements));
 const complete = (context, ast) => Call$(context.async ? 'u' : 't', [ast], context.async);
 const completeOrReturn = (context, ast) => context.head ? complete(context, ast) : ast;
 const completeOrBounce = (context, fAst, argsAsts) =>
@@ -156,71 +156,98 @@ const symbolKey = (context, expr) =>
   isSymbol(expr) && !context.has(expr)
     ? Literal(nameOf(expr))
     : Call$('nameOf', [cast('Symbol', build(context.now(), expr))]);
-const buildLambda = (context, params, body) =>
-  Call$('fun', [
-    Arrow(
-      params.map(x => Identifier(nameOf(x))),
-      uncast(build(context.later().add(params.map(asSymbol)), body)),
-      context.async)]);
-/*
-  expr[1] === shenTrue
-    ? uncast(build(context, expr[2]))
-    : Conditional(
-        cast('JsBool', build(context.now(), expr[1])),
-        ...expr.slice(2).map(x => uncast(build(context, x))))) :
- */
 const buildIf = (context, expr) => {
+  if (expr[1] === shenTrue) {
+    return fab(uncast(build(context, expr[2])));
+  }
   const [condFab, trueFab, falseFab] = expr.slice(1).map(x => build(context, x));
   if (trueFab.anyStatements() || falseFab.anyStatements()) {
-    const resultId = tempId();
+    const resultId    = tempId();
+    const trueResult  = Statement(Assign(resultId, trueFab.expression));
+    const falseResult = Statement(Assign(resultId, falseFab.expression));
     return fab(
       resultId, [
         Let(resultId),
         If(
           cast('JsBool', condFab.expression),
-          Block(...trueFab.statements, Statement(Assign(resultId, trueFab.expression))),
-          Block(...falseFab.statements, Statement(Assign(resultId, falseFab.expression))))]);
+          trueFab.anyStatements()  ? Block(...trueFab.statements,  trueResult)  : trueResult,
+          falseFab.anyStatements() ? Block(...falseFab.statements, falseResult) : falseResult)]);
   } else {
     return fab(Conditional(condFab.expression, trueFab.expression, falseFab.expression), condFab.statements);
   }
 };
+const buildCond = (context, expr) =>
+  // TODO: does this uncast do anything? should there be uncasts on the branches of if instead?
+  uncast(build(context, expr.slice(1).reduceRight(
+    (alternate, [test, consequent]) => [s`if`, test, consequent, alternate],
+    [s`simple-error`, 'no condition was true'])));
+const buildDo = (context, [_do, ...exprs]) => {
+  // TODO: flatten do's
+  const exprFabs = exprs.map(x => uncast(build(context, x)));
+  if (exprFabs.some(x => x.anyStatements())) {
+    return fab(
+      uncast(last(exprFabs).expression),
+      concat(
+        flatMap(butLast(exprFabs), x => concat(x.statements, Statement(x.expression))),
+        last(exprFabs).statements));
+  }
+  return fab(Sequence(...exprFabs.map(x => x.expression)));
+};
+const buildLet = (context, [_let, symbol, binding, body]) => {
+  const bindingFab = uncast(build(context.now(), binding));
+  const bodyFab = uncast(build(context.add([asSymbol(symbol)]), body));
+  const constStmt = Const(Identifier(nameOf(symbol)), bindingFab.expression);
+  return fab(bodyFab.expression, [...bindingFab.statements, constStmt, ...bodyFab.statements]);
+};
+const buildHandler = (context, handler) => {
+  if (isForm(handler, 'lambda', 3)) {
+    const handlerFab = uncast(build(context.add([handler[1]]), handler[2]));
+    return Catch(Identifier(nameOf(handler[1])), Block(...handlerFab.statements, output(handlerFab.expression)));
+  } else {
+    const handlerFab = uncast(build(context, handler));
+    const errorId = RawIdentifier('e$');
+    return Catch(errorId, Block(...handlerFab.statements, output(Call(handlerFab.expression, [errorId], context.async))));
+  }
+};
+const buildTrap = (context, [_trap, body, handler]) => {
+  const resultId = tempId();
+  const output = x => Statement(Assign(resultId, x));
+  const bodyFab = uncast(build(context, body));
+  return fab(resultId, [
+    Let(resultId),
+    Try(
+      Block(...bodyFab.statements, output(bodyFab.expression)),
+      buildHandler(context, handler))]);
+};
+const buildLambda = (context, params, body) => // TODO: update for fabs
+  Call$('fun', [
+    Arrow(
+      params.map(x => Identifier(nameOf(x))),
+      uncast(build(context.later().add(params.map(asSymbol)), body)),
+      context.async)]);
+const buildDefun = (context, [_defun, symbol, params, body]) =>
+  Sequence(Assign(Member$f(nameOf(symbol)), buildLambda(context.clear(), params, body)), idle(symbol));
+const buildApp = (context, [fExpr, ...argExprs]) =>
+  assemble(
+    (f, ...args) => completeOrBounce(context, f, args),
+    context.has(fExpr) ? Identifier(nameOf(fExpr)) :
+    isArray(fExpr)     ? build(context.now(), fExpr) :
+    isSymbol(fExpr)    ? Member$f(nameOf(fExpr)) :
+    raise('not a valid application form'),
+    ...argExprs.map(x => uncast(build(context.now(), x))));
 const build = (context, expr) =>
   isNumber(expr) ? fab(ann('Number', Literal(expr))) :
   isString(expr) ? fab(ann('String', Literal(expr))) :
   isEArray(expr) ? fab(ann('Null',   Literal(null))) :
   isSymbol(expr) ? fab(context.has(expr) ? Identifier(nameOf(expr)) : idle(expr)) :
-  isForm(expr, 'if', 4) ? buildIf(context, expr) :
-  isForm(expr, 'cond') ?
-    // TODO: does this uncast do anything?
-    uncast(build(context, expr.slice(1).reduceRight(
-      (alternate, [test, consequent]) => [s`if`, test, consequent, alternate],
-      [s`simple-error`, 'no condition was true']))) :
-  isForm(expr, 'do', 3) ? Do(build(context.now(), expr[1]), uncast(build(context, expr[2]))) :
-  isForm(expr, 'let', 4) ?
-    Call(
-      Arrow(
-        [Identifier(nameOf(expr[1]))],
-        uncast(build(context.add([asSymbol(expr[1])]), expr[3])),
-        context.async),
-      [uncast(build(context.now(), expr[2]))],
-      context.async) :
-  isForm(expr, 'trap-error', 3) ?
-    completeOrReturn(
-      context,
-      Iife(Block(
-        Try(
-          Block(Return(uncast(build(context.now(), expr[1])))),
-          Catch(
-            isForm(expr[2], 'lambda', 3) ? Identifier(nameOf(expr[2][1])) : RawIdentifier('e$'),
-            Block(Return(
-              isForm(expr[2], 'lambda', 3)
-                ? uncast(build(context.later().add([asSymbol(expr[2][1])]), expr[2][2]))
-                : Call(uncast(build(context.later(), expr[2])), [RawIdentifier('e$')])))))),
-      context.async)) :
-  isForm(expr, 'lambda', 3) ? buildLambda(context, [expr[1]], expr[2]) :
-  isForm(expr, 'freeze', 2) ? buildLambda(context, [], expr[1]) :
-  isForm(expr, 'defun', 4) ?
-    Do(Assign(Member$f(nameOf(expr[1])), buildLambda(context.clear(), expr[2], expr[3])), idle(expr[1])) :
+  isForm(expr, 'if', 4)         ? buildIf    (context, expr) :
+  isForm(expr, 'cond')          ? buildCond  (context, expr) :
+  isForm(expr, 'do', 3)         ? buildDo    (context, expr) :
+  isForm(expr, 'let', 4)        ? buildLet   (context, expr) :
+  isForm(expr, 'trap-error', 3) ? buildTrap  (context, expr) :
+  isForm(expr, 'lambda', 3)     ? buildLambda(context, [expr[1]], expr[2]) :
+  isForm(expr, 'freeze', 2)     ? buildLambda(context, [], expr[1]) :
+  isForm(expr, 'defun', 4)      ? buildDefun (context, expr) :
   isConsForm(expr, 8) ?
     ann('Cons', Call$('consFromArray',
       [Vector(produce(x => isForm(x, 'cons', 3), x => uncast(build(context.now(), x[1])), x => x[2], expr))])) :
@@ -230,14 +257,7 @@ const build = (context, expr) =>
     Call$('valueOf', [symbolKey(context, expr[1])]) :
   isPrimitiveApplication(context, expr) ?
     context.primitives[nameOf(expr[0])](...expr.slice(1).map(x => build(context.now(), x))) :
-  isArray(expr) ?
-    completeOrBounce(
-      context,
-      context.has(expr[0]) ? Identifier(nameOf(expr[0])) :
-      isArray(expr[0])     ? uncast(build(context.now(), expr[0])) :
-      isSymbol(expr[0])    ? Member$f(nameOf(expr[0])) :
-      raise('not a valid application form'),
-      expr.slice(1).map(arg => uncast(build(context.now(), arg)))) :
+  isArray(expr) ? buildApp(context, expr) :
   raise('not a valid form');
 
 module.exports = (options = {}) => {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -154,6 +154,12 @@ const uncast = ast =>
     : (ast.dataType === 'JsBool' ? cast('ShenBool', ast) : ast);
 const isForm = (expr, lead, length) => isNeArray(expr) && expr[0] === symbolOf(lead) && (!length || expr.length === length);
 const isInline = (context, expr) => isNeArray(expr) && isSymbol(expr[0]) && context.primitives.hasOwnProperty(nameOf(expr[0])) && context.primitives[nameOf(expr[0])].length === expr.length - 1;
+const appears = (symbol, expr) =>
+  isForm(expr, 'let', 4)    ? appears(symbol, expr[2]) || (symbol !== expr[1] && appears(symbol, expr[3])) :
+  isForm(expr, 'lambda', 3) ? symbol !== expr[1] && appears(symbol, expr[2]) :
+  isForm(expr, 'defun', 4)  ? !expr[2].includes(symbol) && appears(symbol, expr[3]) :
+  isNeArray(expr)           ? expr.some(x => appears(symbol, x)) :
+  symbol === expr;
 const idle = id => ann('Symbol', adorn(Member$('s'), nameOf(id)));
 const fab = (expression, statements = []) => new Fabrication(expression, statements);
 const assemble = (combine, ...fabs) => fab(combine(...fabs.map(x => x.expression)), flatMap(fabs, x => x.statements));
@@ -199,11 +205,19 @@ const buildDo = (context, [_do, ...exprs]) => {
 const buildLet = (context, [_let, symbol, binding, body]) => {
   // TODO: when shadowing variable in surrounding scope, this won't be able to
   //       initialize in terms of pre-existing variable
+  // TODO: if symbol does not appear in body, can convert (let X Y Z) to (do Y Z)
+  if (!appears(symbol, body)) {
+    // TODO: unnecessary uncast?
+    return uncast(build(context, [s`do`, binding, body]));
+  }
+  // TODO: if symbol appears in binding, need temp variable to construct init value (THIS DOESN"T WORK)
+  //       can later be improved with variable renaming?
   const bindingFab = uncast(build(context.now(), binding));
   const bodyFab = uncast(build(context.add([asSymbol(symbol)]), body));
   const symbolId = Identifier(nameOf(symbol));
   const constStmt = Const(symbolId, bindingFab.expression);
   if (context.has(symbol)) {
+    // TODO: additional block can be avoided if there's already a block between here and outer variable scope
     const [resultId, output] = placeholder();
     return fab(resultId, [
       Let(resultId),

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -167,8 +167,8 @@ const buildIf = (context, expr) => {
     return uncast(build(context, expr[2]));
   }
   const condFab = cast('JsBool', build(context.now(), expr[1]));
-  const trueFab = build(context, expr[2]);
-  const falseFab = build(context, expr[3]);
+  const trueFab = uncast(build(context, expr[2]));
+  const falseFab = uncast(build(context, expr[3]));
   if (trueFab.anyStatements() || falseFab.anyStatements()) {
     const [resultId, output] = placeholder();
     return fab(
@@ -187,17 +187,18 @@ const buildCond = (context, expr) =>
     (alternate, [test, consequent]) => [s`if`, test, consequent, alternate],
     [s`simple-error`, 'no condition was true'])));
 const buildDo = (context, [_do, ...exprs]) => {
-  // TODO: flatten do's
-  const exprFabs = exprs.map(x => uncast(build(context, x)));
+  // TODO: flatten do's ?
+  const exprFabs = [...butLast(exprs).map(x => uncast(build(context.now(), x))), uncast(build(context, last(exprs)))];
   if (exprFabs.some(x => x.anyStatements())) {
-    return fab(
-      uncast(last(exprFabs).expression), [
-        ...flatMap(butLast(exprFabs), x => [...x.statements, Statement(x.expression)]),
-        last(exprFabs).statements]);
+    return fab(last(exprFabs).expression, [
+      ...flatMap(butLast(exprFabs), x => [...x.statements, Statement(x.expression)]),
+      ...last(exprFabs).statements]);
   }
   return fab(Sequence(...exprFabs.map(x => x.expression)));
 };
 const buildLet = (context, [_let, symbol, binding, body]) => {
+  // TODO: when shadowing variable in surrounding scope, this won't be able to
+  //       initialize in terms of pre-existing variable
   const bindingFab = uncast(build(context.now(), binding));
   const bodyFab = uncast(build(context.add([asSymbol(symbol)]), body));
   const symbolId = Identifier(nameOf(symbol));
@@ -222,7 +223,7 @@ const buildHandler = (context, handler, output) => {
 };
 const buildTrap = (context, [_trap, body, handler]) => {
   const [resultId, output] = placeholder();
-  const bodyFab = uncast(build(context, body));
+  const bodyFab = uncast(build(context.now(), body));
   return fab(resultId, [
     Let(resultId),
     Try(
@@ -250,21 +251,21 @@ const buildCons = (context, expr) => {
 const buildSet = (context, [_set, symbol, value]) =>
   assemble(
     (sym, val) => Assign(Member(Member$('symbols'), symbolKey(sym)), val),
-    build(context.now(), symbol),
+    uncast(build(context.now(), symbol)),
     uncast(build(context.now(), value)));
 const buildValue = (context, [_value, symbol]) =>
   assemble(
     sym => Call$('valueOf', [symbolKey(sym)]),
-    build(context.now(), symbol));
+    uncast(build(context.now(), symbol)));
 const buildInline = (context, [fExpr, ...argExprs]) =>
   assemble(
     context.primitives[nameOf(fExpr)],
-    ...argExprs.map(x => build(context.now(), x)));
+    ...argExprs.map(x => uncast(build(context.now(), x)))); // TODO: remove this uncast, individual prims handle that
 const buildApp = (context, [fExpr, ...argExprs]) =>
   assemble(
     (f, ...args) => completeOrBounce(context, f, args),
     context.has(fExpr) ? fab(Identifier(nameOf(fExpr))) :
-    isArray(fExpr)     ? build(context.now(), fExpr) :
+    isArray(fExpr)     ? uncast(build(context.now(), fExpr)) :
     isSymbol(fExpr)    ? fab(Member$f(nameOf(fExpr))) :
     raise('not a valid application form'),
     ...argExprs.map(x => uncast(build(context.now(), x))));

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -1,7 +1,7 @@
 const {
   adorn, ann, generate,
-  Arrow, Assign, Binary, Block, Call, Catch, Do, Identifier, If, Iife,
-  Literal, Member, RawIdentifier, Return, Try, Unary, Vector
+  Arrow, Assign, Binary, Block, Call, Catch, Conditional, Identifier, If, Iife,
+  Literal, Member, RawIdentifier, Return, Sequence, Statement, Try, Unary, Vector
 } = require('./ast');
 const { AsyncFunction, flatMap, produce, raise, s } = require('./utils');
 
@@ -19,9 +19,7 @@ const Trampoline = class {
     this.args = args;
     Object.freeze(this);
   }
-  run() {
-    return this.f(...this.args);
-  }
+  run() { return this.f(...this.args); }
 };
 
 const Context = class {
@@ -51,11 +49,8 @@ const Fabrication = class {
     this.statements = statements;
     Object.freeze(this);
   }
+  anyStatements() { return this.statements.length > 0; }
 };
-
-const fab = (expression, statements = []) => new Fabrication(expression, statements);
-const asm = (combine, ...constructs) =>
-  fab(combine(...constructs.map(x => x.expression)), flatMap(constructs, x => x.statements));
 
 const nameOf     = Symbol.keyFor;
 const symbolOf   = Symbol.for;
@@ -137,6 +132,9 @@ const future = async x => {
   return x;
 };
 
+let counter = 0;
+const tempId = () => RawIdentifier(`R${counter++}$`);
+
 const Member$ = name => Member(RawIdentifier('$'), RawIdentifier(name));
 const Member$f = name => Member(Member$('f'), Literal(name));
 const Call$ = (name, args, async = false) => Call(Member$(name), args, async);
@@ -147,6 +145,9 @@ const isForm = (expr, lead, length) => isNeArray(expr) && expr[0] === symbolOf(l
 const isConsForm = (expr, depth) => depth === 0 || isForm(expr, 'cons', 3) && isConsForm(expr[2], depth - 1);
 const isPrimitiveApplication = (context, expr) => isNeArray(expr) && isSymbol(expr[0]) && context.primitives.hasOwnProperty(nameOf(expr[0])) && context.primitives[nameOf(expr[0])].length === expr.length - 1;
 const idle = id => ann('Symbol', adorn(Member$('s'), nameOf(id)));
+const fab = (expression, statements = []) => new Fabrication(expression, statements);
+const asm = (combine, ...constructs) =>
+  fab(combine(...constructs.map(x => x.expression)), flatMap(constructs, x => x.statements));
 const complete = (context, ast) => Call$(context.async ? 'u' : 't', [ast], context.async);
 const completeOrReturn = (context, ast) => context.head ? complete(context, ast) : ast;
 const completeOrBounce = (context, fAst, argsAsts) =>
@@ -155,22 +156,42 @@ const symbolKey = (context, expr) =>
   isSymbol(expr) && !context.has(expr)
     ? Literal(nameOf(expr))
     : Call$('nameOf', [cast('Symbol', build(context.now(), expr))]);
-const lambda = (context, params, body) =>
+const buildLambda = (context, params, body) =>
   Call$('fun', [
     Arrow(
       params.map(x => Identifier(nameOf(x))),
       uncast(build(context.later().add(params.map(asSymbol)), body)),
       context.async)]);
+/*
+  expr[1] === shenTrue
+    ? uncast(build(context, expr[2]))
+    : Conditional(
+        cast('JsBool', build(context.now(), expr[1])),
+        ...expr.slice(2).map(x => uncast(build(context, x))))) :
+ */
+const buildIf = (context, expr) => {
+  const [condFab, trueFab, falseFab] = expr.slice(1).map(x => build(context, x));
+  if (trueFab.anyStatements() || falseFab.anyStatements()) {
+    const resultId = tempId();
+    return fab(
+      resultId, [
+        Let(resultId),
+        If(
+          cast('JsBool', condFab.expression),
+          Block(...trueFab.statements, Statement(Assign(resultId, trueFab.expression))),
+          Block(...falseFab.statements, Statement(Assign(resultId, falseFab.expression))))]);
+  } else {
+    return fab(Conditional(condFab.expression, trueFab.expression, falseFab.expression), condFab.statements);
+  }
+};
 const build = (context, expr) =>
-  isNumber(expr) ? ann('Number', Literal(expr)) :
-  isString(expr) ? ann('String', Literal(expr)) :
-  isEArray(expr) ? ann('Null',   Literal(null)) :
-  isSymbol(expr) ? (context.has(expr) ? Identifier(nameOf(expr)) : idle(expr)) :
-  isForm(expr, 'if', 4) ? (
-    expr[1] === shenTrue
-      ? uncast(build(context, expr[2]))
-      : If(cast('JsBool', build(context.now(), expr[1])), ...expr.slice(2).map(x => uncast(build(context, x))))) :
+  isNumber(expr) ? fab(ann('Number', Literal(expr))) :
+  isString(expr) ? fab(ann('String', Literal(expr))) :
+  isEArray(expr) ? fab(ann('Null',   Literal(null))) :
+  isSymbol(expr) ? fab(context.has(expr) ? Identifier(nameOf(expr)) : idle(expr)) :
+  isForm(expr, 'if', 4) ? buildIf(context, expr) :
   isForm(expr, 'cond') ?
+    // TODO: does this uncast do anything?
     uncast(build(context, expr.slice(1).reduceRight(
       (alternate, [test, consequent]) => [s`if`, test, consequent, alternate],
       [s`simple-error`, 'no condition was true']))) :
@@ -196,10 +217,10 @@ const build = (context, expr) =>
                 ? uncast(build(context.later().add([asSymbol(expr[2][1])]), expr[2][2]))
                 : Call(uncast(build(context.later(), expr[2])), [RawIdentifier('e$')])))))),
       context.async)) :
-  isForm(expr, 'lambda', 3) ? lambda(context, [expr[1]], expr[2]) :
-  isForm(expr, 'freeze', 2) ? lambda(context, [], expr[1]) :
+  isForm(expr, 'lambda', 3) ? buildLambda(context, [expr[1]], expr[2]) :
+  isForm(expr, 'freeze', 2) ? buildLambda(context, [], expr[1]) :
   isForm(expr, 'defun', 4) ?
-    Do(Assign(Member$f(nameOf(expr[1])), lambda(context.clear(), expr[2], expr[3])), idle(expr[1])) :
+    Do(Assign(Member$f(nameOf(expr[1])), buildLambda(context.clear(), expr[2], expr[3])), idle(expr[1])) :
   isConsForm(expr, 8) ?
     ann('Cons', Call$('consFromArray',
       [Vector(produce(x => isForm(x, 'cons', 3), x => uncast(build(context.now(), x[1])), x => x[2], expr))])) :

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -143,8 +143,7 @@ const cast = (dataType, ast) => dataType !== ast.dataType ? Object.assign(Call$(
 // TODO: clean this up
 const uncast = ast => ast instanceof Fabrication ? fab(uncast(ast.expression), ast.statements) : ast.dataType === 'JsBool' ? cast('ShenBool', ast) : ast;
 const isForm = (expr, lead, length) => isNeArray(expr) && expr[0] === symbolOf(lead) && (!length || expr.length === length);
-const isConsForm = (expr, depth) => depth === 0 || isForm(expr, 'cons', 3) && isConsForm(expr[2], depth - 1);
-const isPrimitiveApplication = (context, expr) => isNeArray(expr) && isSymbol(expr[0]) && context.primitives.hasOwnProperty(nameOf(expr[0])) && context.primitives[nameOf(expr[0])].length === expr.length - 1;
+const isInline = (context, expr) => isNeArray(expr) && isSymbol(expr[0]) && context.primitives.hasOwnProperty(nameOf(expr[0])) && context.primitives[nameOf(expr[0])].length === expr.length - 1;
 const idle = id => ann('Symbol', adorn(Member$('s'), nameOf(id)));
 const fab = (expression, statements = []) => new Fabrication(expression, statements);
 const assemble = (combine, ...fabs) => fab(combine(...fabs.map(x => x.expression)), flatMap(fabs, x => x.statements));
@@ -152,10 +151,7 @@ const complete = (context, ast) => Call$(context.async ? 'u' : 't', [ast], conte
 const completeOrReturn = (context, ast) => context.head ? complete(context, ast) : ast;
 const completeOrBounce = (context, fAst, argsAsts) =>
   context.head ? complete(context, Call(fAst, argsAsts)) : Call$('b', [fAst, ...argsAsts]);
-const symbolKey = (context, expr) =>
-  isSymbol(expr) && !context.has(expr)
-    ? Literal(nameOf(expr))
-    : Call$('nameOf', [cast('Symbol', build(context.now(), expr))]);
+const symbolKey = ast => Call$('nameOf', [cast('Symbol', ast)]); // TODO: no longer optimizes literal symbols
 const buildIf = (context, expr) => {
   if (expr[1] === shenTrue) {
     return fab(uncast(build(context, expr[2])));
@@ -172,9 +168,8 @@ const buildIf = (context, expr) => {
           cast('JsBool', condFab.expression),
           trueFab.anyStatements()  ? Block(...trueFab.statements,  trueResult)  : trueResult,
           falseFab.anyStatements() ? Block(...falseFab.statements, falseResult) : falseResult)]);
-  } else {
-    return fab(Conditional(condFab.expression, trueFab.expression, falseFab.expression), condFab.statements);
   }
+  return fab(Conditional(condFab.expression, trueFab.expression, falseFab.expression), condFab.statements);
 };
 const buildCond = (context, expr) =>
   // TODO: does this uncast do anything? should there be uncasts on the branches of if instead?
@@ -219,14 +214,31 @@ const buildTrap = (context, [_trap, body, handler]) => {
       Block(...bodyFab.statements, output(bodyFab.expression)),
       buildHandler(context, handler))]);
 };
-const buildLambda = (context, params, body) => // TODO: update for fabs
-  Call$('fun', [
-    Arrow(
-      params.map(x => Identifier(nameOf(x))),
-      uncast(build(context.later().add(params.map(asSymbol)), body)),
-      context.async)]);
+const buildLambda = (context, params, body) =>
+  fab(Call$('fun', [Arrow(
+    params.map(x => Identifier(nameOf(x))),
+    uncast(build(context.later().add(params.map(asSymbol)), body)), // TODO: body gets built in return situation
+    context.async)]));
 const buildDefun = (context, [_defun, symbol, params, body]) =>
-  Sequence(Assign(Member$f(nameOf(symbol)), buildLambda(context.clear(), params, body)), idle(symbol));
+  // TODO: in ignore situation, the idle symbol and be dropped
+  fab(Sequence(Assign(Member$f(nameOf(symbol)), buildLambda(context.clear(), params, body)), idle(symbol)));
+const buildCons = (context, expr) =>
+  assemble(
+    xs => ann('Cons', Call$('consFromArray', [Vector(xs)])),
+    produce(x => isForm(x, 'cons', 3), x => uncast(build(context.now(), x[1])), x => x[2], expr));
+const buildSet = (context, [_set, symbol, value]) =>
+  assemble(
+    (sym, val) => Assign(Member(Member$f('symbols'), symbolKey(sym)), val),
+    build(context.now(), symbol),
+    uncast(build(context.now(), value)));
+const buildValue = (context, [_value, symbol]) =>
+  assemble(
+    sym => Call$('valueOf', [symbolKey(sym)]),
+    build(context.now(), symbol));
+const buildInline = (context, [fExpr, ...argExprs]) =>
+  assemble(
+    context.primitives[nameOf(fExpr)],
+    argExprs.map(x => build(context.now(), x)));
 const buildApp = (context, [fExpr, ...argExprs]) =>
   assemble(
     (f, ...args) => completeOrBounce(context, f, args),
@@ -248,16 +260,11 @@ const build = (context, expr) =>
   isForm(expr, 'lambda', 3)     ? buildLambda(context, [expr[1]], expr[2]) :
   isForm(expr, 'freeze', 2)     ? buildLambda(context, [], expr[1]) :
   isForm(expr, 'defun', 4)      ? buildDefun (context, expr) :
-  isConsForm(expr, 8) ?
-    ann('Cons', Call$('consFromArray',
-      [Vector(produce(x => isForm(x, 'cons', 3), x => uncast(build(context.now(), x[1])), x => x[2], expr))])) :
-  isForm(expr, 'set', 3) ?
-    Assign(Member(Member$('symbols'), symbolKey(context, expr[1])), uncast(build(context.now(), expr[2]))) :
-  isForm(expr, 'value', 2) ?
-    Call$('valueOf', [symbolKey(context, expr[1])]) :
-  isPrimitiveApplication(context, expr) ?
-    context.primitives[nameOf(expr[0])](...expr.slice(1).map(x => build(context.now(), x))) :
-  isArray(expr) ? buildApp(context, expr) :
+  isForm(expr, 'cons', 3)       ? buildCons  (context, expr) :
+  isForm(expr, 'set', 3)        ? buildSet   (context, expr) :
+  isForm(expr, 'value', 2)      ? buildValue (context, expr) :
+  isInline(context, expr)       ? buildInline(context, expr) :
+  isArray(expr)                 ? buildApp   (context, expr) :
   raise('not a valid form');
 
 module.exports = (options = {}) => {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -3,7 +3,7 @@ const {
   Arrow, Assign, Binary, Block, Call, Catch, Conditional, Const, Identifier, If, Iife,
   Let, Literal, Member, RawIdentifier, Return, Sequence, Statement, Try, Unary, Vector
 } = require('./ast');
-const { AsyncFunction, butLast, last, flatMap, produce, raise, s } = require('./utils');
+const { AsyncFunction, butLast, last, flatMap, produce, produceState, raise, s } = require('./utils');
 
 const Cons = class {
   constructor(head, tail) {
@@ -90,7 +90,7 @@ const asJsBool   = x =>
 const cons               = (h, t) => new Cons(h, t);
 const valueFromArray     = x => isArray(x) ? consFromArray(x) : x;
 const valueFromArrayTree = x => isArray(x) ? consFromArrayTree(x) : x;
-const consFromArray      = a => a.reduceRight((t, h) => cons(h, t), null);
+const consFromArray      = (a, z = null) => a.reduceRight((t, h) => cons(h, t), z);
 const consFromArrayTree  = a => consFromArray(a.map(valueFromArrayTree));
 const consToArray        = c => produce(isCons, c => c.head, c => c.tail, c);
 const consToArrayTree    = c => consToArray(c).map(valueToArrayTree);
@@ -241,10 +241,12 @@ const buildDefun = (context, [_defun, symbol, params, body]) =>
   // NOTE: buildLambda should never return a fab with statements,
   //       factor out code to emit JsExpr instead of Fab to another function?
   fab(Sequence(Assign(Member$f(nameOf(symbol)), buildLambda(context.clear(), params, body).expression), idle(symbol)));
-const buildCons = (context, expr) =>
-  assemble(
-    (...xs) => ann('Cons', Call$('consFromArray', [Vector(xs)])),
-    ...produce(x => isForm(x, 'cons', 3), x => uncast(build(context.now(), x[1])), x => x[2], expr));
+const buildCons = (context, expr) => {
+  const { result, state } = produceState(x => isForm(x, 'cons', 3), x => x[1], x => x[2], expr);
+  return assemble(
+    (...xs) => ann('Cons', Call$('consFromArray', [Vector(butLast(xs)), last(xs)])),
+    ...[...result, state].map(x => uncast(build(context.now(), x))));
+};
 const buildSet = (context, [_set, symbol, value]) =>
   assemble(
     (sym, val) => Assign(Member(Member$('symbols'), symbolKey(sym)), val),

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -214,11 +214,13 @@ const buildTrap = (context, [_trap, body, handler]) => {
       Block(...bodyFab.statements, output(bodyFab.expression)),
       buildHandler(context, handler))]);
 };
-const buildLambda = (context, params, body) =>
-  fab(Call$('fun', [Arrow(
+const buildLambda = (context, params, body) => {
+  const bodyFab = uncast(build(context.later().add(params.map(asSymbol)), body));
+  return fab(Call$('fun', [Arrow(
     params.map(x => Identifier(nameOf(x))),
-    uncast(build(context.later().add(params.map(asSymbol)), body)), // TODO: body gets built in return situation
+    bodyFab.anyStatements() ? Block(...bodyFab.statements, Return(bodyFab.expression)) : bodyFab.expression,
     context.async)]));
+};
 const buildDefun = (context, [_defun, symbol, params, body]) =>
   // TODO: in ignore situation, the idle symbol and be dropped
   fab(Sequence(Assign(Member$f(nameOf(symbol)), buildLambda(context.clear(), params, body)), idle(symbol)));

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -27,9 +27,9 @@ const Context = class {
     Object.assign(this, options);
     Object.freeze(this);
   }
-  with(options) { return new Context({ ...this, ...options }) }
-  now()         { return this.with({ head: true }); }
-  later()       { return this.with({ head: false }); }
+  with(options)  { return new Context({ ...this, ...options }) }
+  now()          { return this.with({ head: true }); }
+  later()        { return this.with({ head: false }); }
 
   // TODO: these won't be necessary for the initial solution?
   // TODO: instead of "situations", Context could carry a continuation
@@ -37,15 +37,24 @@ const Context = class {
   //       always assinging to a result variable
   // NOTE: returned ast will need meta indicating if continuation was applied
   //       or result is still an expression
-  evaluated()   { return this.with({ situation: 'evaluated' }); }
-  passed()      { return this.with({ situation: 'passed' }); } // might not be necessary/redundant with evaluated
-  returned()    { return this.with({ situation: 'returned' }); } // continuation: x => Return(x)
-  assigned()    { return this.with({ situation: 'assigned' }); } // continuation: x => Assign(tempId, x)
-  ignored()     { return this.with({ situation: 'ignored' }); }  // continuation: x => Statement(x)
+  evaluated()    { return this.with({ situation: 'evaluated' }); }
+  passed()       { return this.with({ situation: 'passed' }); } // might not be necessary/redundant with evaluated
+  returned()     { return this.with({ situation: 'returned' }); } // continuation: x => Return(x)
+  assigned()     { return this.with({ situation: 'assigned' }); } // continuation: x => Assign(tempId, x)
+  ignored()      { return this.with({ situation: 'ignored' }); }  // continuation: x => Statement(x)
 
-  clear()       { return this.with({ locals: new Set() }); }
-  add(locals)   { return this.with({ locals: new Set([...this.locals, ...locals]) }); }
-  has(local)    { return this.locals.has(local); }
+  clear()        { return this.with({ locals: new Map() }); }
+  add(...locals) { return this.with({ locals: new Map([...this.locals, ...locals]) }); }
+  has(local)     { return this.locals.has(local); }
+  get(local)     { return this.locals.get(local); }
+  ann(local, dataType) {
+    return this.with({
+      locals: new Map([
+        ...this.locals,
+        [local, { ...(this.get(local) || {}), dataType }]
+      ])
+    });
+  }
 };
 
 const Fabrication = class {
@@ -146,6 +155,7 @@ const placeholder = () => {
   const id = tempId();
   return [id, x => Statement(Assign(id, x))];
 };
+const makeUnique = x => Identifier(`${nameOf(x)}${counter++}`, '$');
 
 const Member$ = name => Member(RawIdentifier('$'), RawIdentifier(name));
 const Member$f = name => Member(Member$('f'), Literal(name));
@@ -174,6 +184,8 @@ const appears = (symbol, expr) =>
   symbol === expr;
 const idle = id => ann('Symbol', adorn(Member$('s'), nameOf(id)));
 const fab = (expression, statements = []) => new Fabrication(expression, statements);
+// TODO: better name for assemble might be mapFab
+//       functions like assemble are for composing and mapping through Fabs
 const assemble = (combine, ...fabs) => fab(combine(...fabs.map(x => x.expression)), flatMap(fabs, x => x.statements));
 const complete = (context, ast) => Call$(context.async ? 'u' : 't', [ast], context.async);
 const completeOrReturn = (context, ast) => context.head ? complete(context, ast) : ast;
@@ -183,6 +195,7 @@ const buildIf = (context, [_if, condition, ifTrue, ifFalse]) => {
   if (condition === shenTrue) {
     return uncast(build(context, ifTrue));
   }
+  // TODO: check if conditional is asserting type and annotate local meta with the type in the true branch
   const condFab = cast('JsBool', build(context.now(), condition));
   const trueFab = uncast(build(context, ifTrue));
   const falseFab = uncast(build(context, ifFalse));
@@ -221,8 +234,12 @@ const buildLet = (context, [_let, symbol, binding, body]) => {
   // TODO: if symbol appears in binding, need temp variable to construct init value (THIS DOESN"T WORK)
   //       can later be improved with variable renaming?
   const bindingFab = uncast(build(context.now(), binding));
-  const bodyFab = uncast(build(context.add([asSymbol(symbol)]), body));
-  const symbolId = Identifier(nameOf(symbol));
+  const dataType = bindingFab.expression.dataType;
+  // Give unique name for the rare circumstance where shadowing variable defined in terms of shadowed variable
+  const redundant = appears(symbol, binding);
+  const symbolId = redundant ? makeUnique(symbol) : Identifier(nameOf(symbol));
+  const meta = redundant ? { dataType, alt: symbolId } : { dataType };
+  const bodyFab = uncast(build(context.add([asSymbol(symbol), meta]), body));
   const constStmt = Const(symbolId, bindingFab.expression);
   if (context.has(symbol)) {
     // TODO: additional block can be avoided if there's already a block between here and outer variable scope
@@ -236,7 +253,7 @@ const buildLet = (context, [_let, symbol, binding, body]) => {
 };
 const buildHandler = (context, handler, output) => {
   if (isForm(handler, 'lambda', 3)) {
-    const handlerFab = uncast(build(context.add([handler[1]]), handler[2]));
+    const handlerFab = uncast(build(context.add([asSymbol(handler[1]), {}]), handler[2]));
     return Catch(Identifier(nameOf(handler[1])), Block(...handlerFab.statements, output(handlerFab.expression)));
   } else {
     const handlerFab = uncast(build(context, handler));
@@ -254,7 +271,7 @@ const buildTrap = (context, [_trap, body, handler]) => {
       buildHandler(context, handler, output))]);
 };
 const buildLambda = (context, params, body) => {
-  const bodyFab = uncast(build(context.later().add(params.map(asSymbol)), body));
+  const bodyFab = uncast(build(context.later().add(...params.map(x => [asSymbol(x), {}])), body));
   return fab(Call$('fun', [Arrow(
     params.map(x => Identifier(nameOf(x))),
     bodyFab.anyStatements() ? Block(...bodyFab.statements, Return(bodyFab.expression)) : bodyFab.expression,
@@ -306,7 +323,7 @@ const build = (context, expr) =>
   isNumber(expr) ? fab(ann('Number', Literal(expr))) :
   isString(expr) ? fab(ann('String', Literal(expr))) :
   isEArray(expr) ? fab(ann('Null',   Literal(null))) :
-  isSymbol(expr) ? fab(context.has(expr) ? Identifier(nameOf(expr)) : idle(expr)) :
+  isSymbol(expr) ? fab(context.has(expr) ? (context.get(expr).alt || Identifier(nameOf(expr))) : idle(expr)) :
   isForm(expr, 'if', 4)         ? buildIf    (context, expr) :
   isForm(expr, 'cond')          ? buildCond  (context, expr) :
   isForm(expr, 'do', 3)         ? buildDo    (context, expr) :
@@ -447,7 +464,7 @@ module.exports = (options = {}) => {
     'type':         (x, _) => x
   };
   Object.keys(functions).forEach(name => functions[name] = fun(functions[name]));
-  const context = new Context({ async: options.async, head: true, locals: new Set(), primitives });
+  const context = new Context({ async: options.async, head: true, locals: new Map(), primitives });
   // TODO: needs to be in evaluated situation and if it returns prereq statements put in an iife?
   const compile = expr => uncast(build(context, expr));
   const $ = {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -134,6 +134,10 @@ const future = async x => {
 
 let counter = 0;
 const tempId = () => RawIdentifier(`R${counter++}$`);
+const placeholder = () => {
+  const id = tempId();
+  return [id, x => Statement(Assign(id, x))];
+};
 
 const Member$ = name => Member(RawIdentifier('$'), RawIdentifier(name));
 const Member$f = name => Member(Member$('f'), Literal(name));
@@ -158,16 +162,14 @@ const buildIf = (context, expr) => {
   }
   const [condFab, trueFab, falseFab] = expr.slice(1).map(x => build(context, x));
   if (trueFab.anyStatements() || falseFab.anyStatements()) {
-    const resultId    = tempId();
-    const trueResult  = Statement(Assign(resultId, trueFab.expression));
-    const falseResult = Statement(Assign(resultId, falseFab.expression));
+    const [resultId, output] = placeholder();
     return fab(
       resultId, [
         Let(resultId),
         If(
           cast('JsBool', condFab.expression),
-          trueFab.anyStatements()  ? Block(...trueFab.statements,  trueResult)  : trueResult,
-          falseFab.anyStatements() ? Block(...falseFab.statements, falseResult) : falseResult)]);
+          trueFab.anyStatements()  ? Block(...trueFab.statements,  output(trueFab))  : output(trueFab),
+          falseFab.anyStatements() ? Block(...falseFab.statements, output(falseFab)) : output(falseFab))]);
   }
   return fab(Conditional(condFab.expression, trueFab.expression, falseFab.expression), condFab.statements);
 };
@@ -205,13 +207,12 @@ const buildHandler = (context, handler) => {
   }
 };
 const buildTrap = (context, [_trap, body, handler]) => {
-  const resultId = tempId();
-  const output = x => Statement(Assign(resultId, x));
+  const [resultId, output] = placeholder();
   const bodyFab = uncast(build(context, body));
   return fab(resultId, [
     Let(resultId),
     Try(
-      Block(...bodyFab.statements, output(bodyFab.expression)),
+      Block(...bodyFab.statements, output(bodyFab)),
       buildHandler(context, handler))]);
 };
 const buildLambda = (context, params, body) => {

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -230,8 +230,12 @@ const buildIf = (context, [_if, condition, ifTrue, ifFalse]) => {
         Let(resultId),
         If(
           condFab.expression,
-          trueFab.anyStatements()  ? Block(...trueFab.statements,  output(trueFab.expression))  : output(trueFab.expression),
-          falseFab.anyStatements() ? Block(...falseFab.statements, output(falseFab.expression)) : output(falseFab.expression))]);
+          trueFab.anyStatements() ?
+            Block(...trueFab.statements, output(trueFab.expression)) :
+            output(trueFab.expression),
+          falseFab.anyStatements() ?
+            Block(...falseFab.statements, output(falseFab.expression)) :
+            output(falseFab.expression))]);
   }
   return fab(Conditional(condFab.expression, trueFab.expression, falseFab.expression), condFab.statements);
 };

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -48,12 +48,14 @@ const Context = class {
   has(local)     { return this.locals.has(local); }
   get(local)     { return this.locals.get(local); }
   ann(local, dataType) {
-    return this.with({
-      locals: new Map([
-        ...this.locals,
-        [local, { ...(this.get(local) || {}), dataType }]
-      ])
-    });
+    return this.get(local) ?
+      this.with({
+        locals: new Map([
+          ...this.locals,
+          [local, { ...(this.get(local) || {}), dataType }]
+        ])
+      }) :
+      this;
   }
 };
 
@@ -182,6 +184,10 @@ const appears = (symbol, expr) =>
   isForm(expr, 'defun', 4)  ? !expr[2].includes(symbol) && appears(symbol, expr[3]) :
   isNeArray(expr)           ? expr.some(x => appears(symbol, x)) :
   symbol === expr;
+const variable = (context, id) => {
+  const { alt, dataType } = context.get(id);
+  return Object.assign(alt || Identifier(nameOf(id)), { dataType });
+};
 const idle = id => ann('Symbol', adorn(Member$('s'), nameOf(id)));
 const fab = (expression, statements = []) => new Fabrication(expression, statements);
 // TODO: better name for assemble might be mapFab
@@ -191,13 +197,31 @@ const complete = (context, ast) => Call$(context.async ? 'u' : 't', [ast], conte
 const completeOrReturn = (context, ast) => context.head ? complete(context, ast) : ast;
 const completeOrBounce = (context, fAst, argsAsts) =>
   context.head ? complete(context, Call(fAst, argsAsts)) : Call$('b', [fAst, ...argsAsts]);
+const recognisors = {
+  'cons?':      'Cons',
+  'number?':    'Number',
+  'string?':    'String',
+  'symbol?':    'Symbol',
+  'absvector?': 'Array',
+  'boolean?':   'ShenBool'
+};
+const isRecognisor = (context, expr) =>
+  isArray(expr) &&
+  expr.length === 2 &&
+  isSymbol(expr[0]) &&
+  isSymbol(expr[1]) &&
+  recognisors[nameOf(expr[0])] &&
+  [expr[1], recognisors[nameOf(expr[0])]];
 const buildIf = (context, [_if, condition, ifTrue, ifFalse]) => {
   if (condition === shenTrue) {
     return uncast(build(context, ifTrue));
   }
-  // TODO: check if conditional is asserting type and annotate local meta with the type in the true branch
+  // TODO: this same recognisor annotation can be applied in an (and)
+  //       e.g. (and (cons? X) (foo? (hd X)))
+  //        ==> $.isCons(X) && $.f.foop.t(X.head)
+  const recognised = isRecognisor(context, condition);
   const condFab = cast('JsBool', build(context.now(), condition));
-  const trueFab = uncast(build(context, ifTrue));
+  const trueFab = uncast(build(recognised ? context.ann(...recognised) : context, ifTrue));
   const falseFab = uncast(build(context, ifFalse));
   if (trueFab.anyStatements() || falseFab.anyStatements()) {
     const [resultId, output] = placeholder();
@@ -225,25 +249,20 @@ const buildDo = (context, [_do, ...exprs]) => {
   return fab(Sequence(...exprFabs.map(x => x.expression)));
 };
 const buildLet = (context, [_let, symbol, binding, body]) => {
-  // TODO: when shadowing variable in surrounding scope, this won't be able to
-  //       initialize in terms of pre-existing variable
-  // TODO: if symbol does not appear in body, can convert (let X Y Z) to (do Y Z)
   if (!appears(symbol, body)) {
     return build(context, [s`do`, binding, body]);
   }
-  // TODO: if symbol appears in binding, need temp variable to construct init value (THIS DOESN"T WORK)
-  //       can later be improved with variable renaming?
   const bindingFab = uncast(build(context.now(), binding));
   const dataType = bindingFab.expression.dataType;
-  // Give unique name for the rare circumstance where shadowing variable defined in terms of shadowed variable
-  const redundant = appears(symbol, binding);
-  const symbolId = redundant ? makeUnique(symbol) : Identifier(nameOf(symbol));
-  const meta = redundant ? { dataType, alt: symbolId } : { dataType };
+  const conflict = appears(symbol, binding);
+  const symbolId = conflict ? makeUnique(symbol) : Identifier(nameOf(symbol));
+  const meta = conflict ? { dataType, alt: symbolId } : { dataType };
   const bodyFab = uncast(build(context.add([asSymbol(symbol), meta]), body));
   const constStmt = Const(symbolId, bindingFab.expression);
-  if (context.has(symbol)) {
+  if (!conflict && context.has(symbol)) {
     // TODO: additional block can be avoided if there's already a block between here and outer variable scope
-    //       this can be tracked in locals Map in Context
+    //       this can be tracked in locals Map in Context. Entering a new block would switch a property on
+    //       every local to true
     const [resultId, output] = placeholder();
     return fab(resultId, [
       Let(resultId),
@@ -253,7 +272,8 @@ const buildLet = (context, [_let, symbol, binding, body]) => {
 };
 const buildHandler = (context, handler, output) => {
   if (isForm(handler, 'lambda', 3)) {
-    const handlerFab = uncast(build(context.add([asSymbol(handler[1]), {}]), handler[2]));
+    // NOTE: don't need to work about shadow variable clash since catch () {} is always its own block
+    const handlerFab = uncast(build(context.add([asSymbol(handler[1]), { dataType: 'Error' }]), handler[2]));
     return Catch(Identifier(nameOf(handler[1])), Block(...handlerFab.statements, output(handlerFab.expression)));
   } else {
     const handlerFab = uncast(build(context, handler));
@@ -323,7 +343,7 @@ const build = (context, expr) =>
   isNumber(expr) ? fab(ann('Number', Literal(expr))) :
   isString(expr) ? fab(ann('String', Literal(expr))) :
   isEArray(expr) ? fab(ann('Null',   Literal(null))) :
-  isSymbol(expr) ? fab(context.has(expr) ? (context.get(expr).alt || Identifier(nameOf(expr))) : idle(expr)) :
+  isSymbol(expr) ? fab(context.has(expr) ? variable(context, expr) : idle(expr)) :
   isForm(expr, 'if', 4)         ? buildIf    (context, expr) :
   isForm(expr, 'cond')          ? buildCond  (context, expr) :
   isForm(expr, 'do', 3)         ? buildDo    (context, expr) :
@@ -379,7 +399,7 @@ module.exports = (options = {}) => {
     'shen-script.*outstream-supported*': asShenBool(options.isOutStream || options.OutStream)
   };
   const atomicTypes = ['Number', 'String', 'Symbol', 'Stream', 'Null'];
-  const primitives = {
+  const primitives = { // TODO: rename to 'inlines'
     '=': (x, y) =>
       atomicTypes.includes(x.dataType) || atomicTypes.includes(y.dataType)
         ? ann('JsBool', Binary('===', ...[x, y].map(uncast)))
@@ -477,7 +497,11 @@ module.exports = (options = {}) => {
     f: functions, s, b: bounce, t: settle, u: future, async: options.async
 
     // TODO: remove these, they're here for temp debugging
-    , build, context, cast, uncast, generate
+    , build, context, cast, uncast, generate, tryout: expr => {
+      const exprFab = compile(valueToArrayTree(expr));
+      console.log(generate(Block(...exprFab.statements, Return(exprFab.expression))));
+    }
+    // TODO: remove the above
   };
   const Func = context.async ? AsyncFunction : Function;
   functions['eval-kl'] = fun($.evalKl = expr => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,6 @@ const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 const flatMap = (xs, f) => xs.reduce((ys, x) => (ys.push(...f(x)), ys), []);
 const butLast = a => a.length === 0 ? [] : a.slice(0, a.length - 1);
 const last = a => a.length === 0 ? null : a[a.length - 1];
-const concat = (xss...) => flatMap(xss, x => x);
 const mapAsync = async (xs, f) => {
   const ys = [];
   for (const x of xs) {
@@ -28,4 +27,4 @@ const produce = (proceed, select, next, state, result = []) => {
 const raise = x => { throw new Error(x); };
 const s = (x, y) => Symbol.for(String.raw(x, y));
 
-module.exports = { AsyncFunction, flatMap, butLast, last, concat, mapAsync, multiMatch, produce, raise, s };
+module.exports = { AsyncFunction, flatMap, butLast, last, mapAsync, multiMatch, produce, raise, s };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,9 @@
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 
 const flatMap = (xs, f) => xs.reduce((ys, x) => (ys.push(...f(x)), ys), []);
+const butLast = a => a.length === 0 ? [] : a.slice(0, a.length - 1);
 const last = a => a.length === 0 ? null : a[a.length - 1];
+const concat = (xss...) => flatMap(xss, x => x);
 const mapAsync = async (xs, f) => {
   const ys = [];
   for (const x of xs) {
@@ -26,4 +28,4 @@ const produce = (proceed, select, next, state, result = []) => {
 const raise = x => { throw new Error(x); };
 const s = (x, y) => Symbol.for(String.raw(x, y));
 
-module.exports = { AsyncFunction, flatMap, last, mapAsync, multiMatch, produce, raise, s };
+module.exports = { AsyncFunction, flatMap, butLast, last, concat, mapAsync, multiMatch, produce, raise, s };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,16 @@
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 
-const flatMap = (xs, f) => xs.reduce((ys, x) => (ys.push(...f(x)), ys), []);
+const flatMap = (xs, f) => {
+  const ys = [];
+  for (const x of xs) {
+    for (const y of f(x)) {
+      ys.push(y);
+    }
+  }
+  return ys;
+};
 const butLast = a => a.length === 0 ? [] : a.slice(0, a.length - 1);
-const last = a => a.length === 0 ? null : a[a.length - 1];
+const last = a => a.length === 0 ? undefined : a[a.length - 1];
 const mapAsync = async (xs, f) => {
   const ys = [];
   for (const x of xs) {
@@ -18,13 +26,15 @@ const multiMatch = (key, ...pairs) => {
   }
   return 'Unknown';
 };
-const produce = (proceed, select, next, state, result = []) => {
+const produceState = (proceed, select, next, state, result = []) => {
   for (; proceed(state); state = next(state)) {
     result.push(select(state));
   }
-  return result;
+  return { result, state };
 };
+const produce = (proceed, select, next, state, result = []) =>
+  produceState(proceed, select, next, state, result).result;
 const raise = x => { throw new Error(x); };
 const s = (x, y) => Symbol.for(String.raw(x, y));
 
-module.exports = { AsyncFunction, flatMap, butLast, last, mapAsync, multiMatch, produce, raise, s };
+module.exports = { AsyncFunction, flatMap, butLast, last, mapAsync, multiMatch, produce, produceState, raise, s };

--- a/package-lock.json
+++ b/package-lock.json
@@ -251,23 +251,15 @@
       }
     },
     "ecstatic": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.1.tgz",
-      "integrity": "sha512-/rrctvxZ78HMI/tPIsqdvFKHHscxR3IJuKrZI2ZoUgkt2SiufyLFBmcco+aqQBIu6P1qBsUNG3drAAGLx80vTQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "dev": true,
       "requires": {
         "he": "^1.1.1",
         "mime": "^1.6.0",
         "minimist": "^1.1.0",
         "url-join": "^2.0.5"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
-        }
       }
     },
     "emoji-regex": {
@@ -739,6 +731,12 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "scripts": {
     "lint": "eslint index.js lib/**/*.js scripts/**/*.js test/**/*.js",
-    "test": "npm run test-backend -- --reporter dot",
+    "test": "echo \"Run test-backend, test-kernel and test-frontend\"",
     "fetch-kernel": "node scripts/fetch.js",
-    "test-backend": "mocha test/backend/test.*.js",
+    "test-backend": "mocha test/backend/test.*.js --reporter dot",
     "render-kernel": "node scripts/render.js",
     "test-kernel": "node test/kernel/test.kernel.js",
-    "test-frontend": "mocha test/frontend/test.*.js",
+    "test-frontend": "mocha test/frontend/test.*.js --reporter dot",
     "repl": "node scripts/repl.js",
     "start": "http-server -p 8080"
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "lint": "eslint index.js lib/**/*.js scripts/**/*.js test/**/*.js",
-    "test": "echo \"Run test-backend, test-kernel and test-frontend\"",
+    "test": "npm run test-backend && npm run test-frontend",
     "fetch-kernel": "node scripts/fetch.js",
     "test-backend": "mocha test/backend/test.*.js --reporter dot",
     "render-kernel": "node scripts/render.js",

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -22,7 +22,7 @@ const syntax =
         // TODO: top-level defuns and statements all start in ignore situation
         ...flatMap([...defuns, ...statements], x => toStatements(compile(x))),
         Return(RawIdentifier('$'))),
-      async)))]));
+      async)))]), { indent: '  ' }); // TODO: try to render each expr on a single line if possible
 
 console.log(`${syntax.length} chars`);
 

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -7,10 +7,12 @@ const {
   Arrow, Assign, Block, Identifier, Member, Program, RawIdentifier, Return, Statement,
   generate
 } = require('../lib/ast');
+const { flatMap } = require('../lib/utils');
 
 const { defuns, statements } = parseKernel();
 const { compile } = backend({ async });
 
+const toStatements = fab => [...fab.statements, Statement(fab.expression)];
 const syntax =
   generate(Program([Statement(Assign(
     Member(Identifier('module'), Identifier('exports')),
@@ -18,8 +20,7 @@ const syntax =
       [RawIdentifier('$')],
       Block(
         // TODO: top-level defuns and statements all start in ignore situation
-        ...defuns    .map(x => Statement(compile(x).expressions[0])),
-        ...statements.map(x => Statement(compile(x))),
+        ...flatMap([...defuns, ...statements], x => toStatements(compile(x))),
         Return(RawIdentifier('$'))),
       async)))]));
 

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -1,5 +1,3 @@
-const async = process.argv.includes('async');
-
 const fs              = require('fs');
 const { parseKernel } = require('./parser');
 const backend         = require('../lib/backend');
@@ -10,24 +8,29 @@ const {
 const { flatMap } = require('../lib/utils');
 
 const { defuns, statements } = parseKernel();
-const { compile } = backend({ async });
 
-const toStatements = fab => [...fab.statements, Statement(fab.expression)];
-const syntax =
-  generate(Program([Statement(Assign(
-    Member(Identifier('module'), Identifier('exports')),
-    Arrow(
-      [RawIdentifier('$')],
-      Block(
-        // TODO: top-level defuns and statements all start in ignore situation
-        ...flatMap([...defuns, ...statements], x => toStatements(compile(x))),
-        Return(RawIdentifier('$'))),
-      async)))]), { indent: '  ' }); // TODO: try to render each expr on a single line if possible
+const render = async => {
+  const { compile } = backend({ async });
+  const toStatements = fab => [...fab.statements, Statement(fab.expression)];
+  const syntax =
+    generate(Program([Statement(Assign(
+      Member(Identifier('module'), Identifier('exports')),
+      Arrow(
+        [RawIdentifier('$')],
+        Block(
+          // TODO: top-level defuns and statements all start in ignore situation
+          ...flatMap([...defuns, ...statements], x => toStatements(compile(x))),
+          Return(RawIdentifier('$'))),
+        async)))]), { indent: '  ' }); // TODO: try to render each expr on a single line if possible
 
-console.log(`${syntax.length} chars`);
+  console.log(`${async ? 'async' : 'sync '} kernel: ${syntax.length} chars`);
 
-if (!fs.existsSync('dist')) {
-  fs.mkdirSync('dist');
-}
+  if (!fs.existsSync('dist')) {
+    fs.mkdirSync('dist');
+  }
 
-fs.writeFileSync(`dist/kernel.${async ? 'async' : 'sync'}.js`, syntax);
+  fs.writeFileSync(`dist/kernel.${async ? 'async' : 'sync'}.js`, syntax);
+};
+
+render(false);
+render(true);

--- a/test/backend/test.async.js
+++ b/test/backend/test.async.js
@@ -74,6 +74,9 @@ describe('async', () => {
         equal(3, await exec('(let X 1 (let X 2 (let X 3 X)))'));
         equal(3, await exec('(let X 1 (if (> X 0) (let X 2 (+ X 1)) 5))'));
       });
+      it('should be able to initialize inner variable in terms of outer variable', async () => {
+        equal(2, await exec('(let X 1 (let X (+ X 1) X))'));
+      });
       it('should shadow outer lambda binding when nested', async () => {
         equal(8, await exec('((lambda X (let X 4 (+ X X))) 3)'));
       });

--- a/test/backend/test.sync.js
+++ b/test/backend/test.sync.js
@@ -32,6 +32,14 @@ describe('sync', () => {
         equal(1, exec('(tl (cons (if (= 0 0) (set x 1) (set x 2)) (value x)))'));
         equal(2, exec('(tl (cons (if (= 0 1) (set x 1) (set x 2)) (value x)))'));
       });
+      it('should evaluate side effects in nested ifs', () => {
+        exec('(if (trap-error (simple-error "fail") (lambda E (do (set x 1) true))) (set y 2) (set y 0))');
+        equal(1, valueOf('x'));
+        equal(2, valueOf('y'));
+        exec('(if (trap-error (simple-error "fail") (lambda E (do (set x 3) false))) (set y 0) (set y 4))');
+        equal(3, valueOf('x'));
+        equal(4, valueOf('y'));
+      });
     });
     describe('and', () => {
       it('should return a Shen boolean', () => {
@@ -101,6 +109,16 @@ describe('sync', () => {
     describe('escaping', () => {
       it('$ should be usable as a variable', () => {
         equal(3, exec('(let $ 2 (+ 1 $))'));
+      });
+    });
+    describe('set/value key optimization', () => {
+      it('should not try to optimize a variable that holds the key value in (value)', () => {
+        exec('(set z 31)');
+        equal(31, exec('(let X z (value X))'));
+      });
+      it('should not try to optimize a variable that holds the key value in (set)', () => {
+        exec('(let X z (set X 37))');
+        equal(37, exec('(value z)'));
       });
     });
   });

--- a/test/backend/test.sync.js
+++ b/test/backend/test.sync.js
@@ -75,6 +75,9 @@ describe('sync', () => {
         equal(3, exec('(let X 1 (let X 2 (let X 3 X)))'));
         equal(3, exec('(let X 1 (if (> X 0) (let X 2 (+ X 1)) 5))'));
       });
+      it('should be able to initialize inner variable in terms of outer variable', () => {
+        equal(2, exec('(let X 1 (let X (+ X 1) X))'));
+      });
       it('should shadow outer lambda binding when nested', () => {
         equal(8, exec('((lambda X (let X 4 (+ X X))) 3)'));
       });


### PR DESCRIPTION
- `Fabrication`s used to build statement-oriented syntax without spurious lambdas.
- 1 additional (2 total) sync kernel tests fail due to stack overflow.
- Generated code is also about 2x the size right now.
- Added 150 lines of code to `backend.js`.

Still plenty of hanging TODOs - going to merge while this is stable.

This is just Phase 1 of this project. In Phase 2, I will try to build more optimized (in terms of code volume) JS by making the code generation process more context sensitive. This will eliminate many/most of the temporary result variables (e.g. `R123$`).