### PR TITLE
Shen 22.0 Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Shen Version](https://img.shields.io/badge/shen-21.2-blue.svg)](https://github.com/Shen-Language)
+[![Shen Version](https://img.shields.io/badge/shen-22.0-blue.svg)](https://github.com/Shen-Language)
 [![Build Status](https://travis-ci.org/rkoeninger/ShenScript.svg?branch=master)](https://travis-ci.org/rkoeninger/ShenScript)
 [![Docs Status](https://readthedocs.org/projects/shenscript/badge/?version=latest)](https://shenscript.readthedocs.io/en/latest/?badge=latest)
 

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -78,7 +78,7 @@ const nameOf     = Symbol.keyFor;
 const symbolOf   = Symbol.for;
 const shenTrue   = s`true`;
 const shenFalse  = s`false`;
-const isObject   = x => typeof x === 'object' && x !== null;
+const isObject   = x => !Array.isArray(x) && typeof x === 'object' && x !== null;
 const isNumber   = x => typeof x === 'number' && Number.isFinite(x);
 const isNzNumber = x => isNumber(x) && x !== 0;
 const isString   = x => typeof x === 'string' || x instanceof String;

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -49,7 +49,7 @@ const Context = class {
 const Cell = class {
   constructor(name) {
     this.name = name;
-    this.f = undefined;
+    this.f = () => raise(`function "${name}" is not defined`);
     this.value = undefined;
     this.valueExists = false;
   }

--- a/lib/frontend.js
+++ b/lib/frontend.js
@@ -9,8 +9,9 @@ const {
 
 module.exports = $ => {
   const {
-    asFunction, asJsBool, asList, asNumber, asShenBool, asString, asSymbol, async, compile, cons, defun, eternal,
-    evalJs, fun, future, inlines, isArray, nameOf, s, settle, symbolOf, toArray, toArrayTree, toListTree, valueOf
+    asFunction, asJsBool, asList, asNumber, asShenBool, asString, asSymbol, async, compile, cons,
+    defun, eternal, evalJs, fun, future, inlines, isArray, nameOf, s, settle, symbolOf, toArray,
+    toArrayTree, toListTree, valueOf
   } = $;
   const macroregCell = eternal('shen.*macroreg*');
   const macrosCell = eternal('*macros*');

--- a/lib/frontend.node.js
+++ b/lib/frontend.node.js
@@ -24,7 +24,12 @@ module.exports = $ => {
    * Declare Port Features *
    *************************/
 
-  caller('shen.x.features.initialise')(toList([s`js`, s`shen-script`, s`node`, symbolOf(valueOf('*os*').toLowerCase())]));
+  const features = [
+    s`shen-script`,
+    s`js`,
+    s`node`,
+    symbolOf(valueOf('*os*').toLowerCase())];
+  caller('shen.x.features.initialise')(toList(features));
 
   return $;
 };

--- a/lib/frontend.node.js
+++ b/lib/frontend.node.js
@@ -1,7 +1,10 @@
 const frontend = require('./frontend');
 
 module.exports = $ => {
-  const { define, defineTyped, defmacro, eternal, isArray, s, symbol } = $ = frontend($);
+  const {
+    caller, define, defineTyped, defmacro, eternal,
+    isArray, s, symbol, symbolOf, toList, valueOf
+  } = $ = frontend($);
 
   defineTyped('node.exit', [s`number`, s`-->`, s`unit`], x => process.exit(x));
   defmacro('node.exit-macro', expr => {
@@ -16,6 +19,12 @@ module.exports = $ => {
   if (!eternal('js.globalThis').valueExists) {
     symbol('js.globalThis', global);
   }
+
+  /*************************
+   * Declare Port Features *
+   *************************/
+
+  caller('shen.x.features.initialise')(toList([s`js`, s`shen-script`, s`node`, symbolOf(valueOf('*os*').toLowerCase())]));
 
   return $;
 };

--- a/lib/frontend.web.js
+++ b/lib/frontend.web.js
@@ -3,8 +3,8 @@ const frontend = require('./frontend');
 
 module.exports = $ => {
   const {
-    asShenBool, asString, async, compile, define, defineTyped, eternal,
-    defmacro, evalJs, inline, isArray, isSymbol, s, symbol
+    asShenBool, asString, async, caller, compile, define, defineTyped, defmacro,
+    eternal, evalJs, inline, isArray, isSymbol, s, symbol, symbolOf, toList, valueOf
   } = $ = frontend($);
 
   defineTyped('web.atob', [s`string`, s`-->`, s`string`], x => atob(asString(x)));
@@ -59,6 +59,12 @@ module.exports = $ => {
       return [s`web.workers.new`, code];
     }
   });
+
+  /*************************
+   * Declare Port Features *
+   *************************/
+
+  caller('shen.x.features.initialise')(toList([s`js`, s`shen-script`, s`web`, symbolOf(valueOf('*os*').toLowerCase())]));
 
   return $;
 };

--- a/lib/frontend.web.js
+++ b/lib/frontend.web.js
@@ -64,7 +64,13 @@ module.exports = $ => {
    * Declare Port Features *
    *************************/
 
-  caller('shen.x.features.initialise')(toList([s`js`, s`shen-script`, s`web`, symbolOf(valueOf('*os*').toLowerCase())]));
+  const features = [
+    s`shen-script`,
+    s`js`,
+    s`web`,
+    symbolOf(valueOf('*implementation*').toLowerCase().split(' ').join('-')),
+    symbolOf(valueOf('*os*').toLowerCase())];
+  caller('shen.x.features.initialise')(toList(features));
 
   return $;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ShenScript",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Shen for JavaScript",
   "author": "Robert Koeninger",
   "license": "BSD-3-Clause",

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,12 +1,25 @@
 module.exports = {
-  kernelVersion: '21.2',
+  kernelVersion: '22.0',
   kernelPath:    'kernel',
   testsPath:     'kernel/tests',
   klPath:        'kernel/klambda',
   klExt:         '.kl',
   klFiles: [
-    'toplevel', 'core',   'sys',          'dict',  'sequent',
-    'yacc',     'reader', 'prolog',       'track', 'load',
-    'writer',   'macros', 'declarations', 'types', 't-star', 'init'
+    'core',
+    'declarations',
+    'dict',
+    'init',
+    'load',
+    'macros',
+    'prolog',
+    'reader',
+    'sequent',
+    'sys',
+    't-star',
+    'toplevel',
+    'track',
+    'types',
+    'writer',
+    'yacc'
   ]
 };

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -20,6 +20,7 @@ module.exports = {
     'track',
     'types',
     'writer',
-    'yacc'
+    'yacc',
+    'extension-features'
   ]
 };

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -21,6 +21,7 @@ module.exports = {
     'types',
     'writer',
     'yacc',
-    'extension-features'
+    'extension-features',
+    'extension-launcher'
   ]
 };

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -7,6 +7,6 @@ module.exports = {
   klFiles: [
     'toplevel', 'core',   'sys',          'dict',  'sequent',
     'yacc',     'reader', 'prolog',       'track', 'load',
-    'writer',   'macros', 'declarations', 'types', 't-star'
+    'writer',   'macros', 'declarations', 'types', 't-star', 'init'
   ]
 };

--- a/scripts/parser.js
+++ b/scripts/parser.js
@@ -1,6 +1,7 @@
 const fs                                      = require('fs');
 const { alt, createLanguage, regexp, string } = require('parsimmon');
 const { klPath, klFiles, klExt }              = require('./config');
+const { flatMap }                             = require('../lib/utils');
 
 const language = createLanguage({
   whitespace: _ => regexp(/\s*/m),
@@ -13,16 +14,6 @@ const language = createLanguage({
 });
 const parseFile = s => language.file.tryParse(s);
 const parseForm = s => parseFile(s)[0];
-const parseKernel = () => {
-  const defuns = [], statements = [];
-
-  klFiles.forEach(file => parseFile(fs.readFileSync(`${klPath}/${file}${klExt}`, 'utf-8')).forEach(expr => {
-    if (Array.isArray(expr) && expr.length > 0) {
-      (expr[0] === Symbol.for('defun') ? defuns : statements).push(expr);
-    }
-  }));
-
-  return { defuns, statements };
-};
+const parseKernel = () => flatMap(klFiles, file => parseFile(fs.readFileSync(`${klPath}/${file}${klExt}`, 'utf-8')));
 
 module.exports = { parseFile, parseForm, parseKernel };

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -5,7 +5,6 @@ const {
   Arrow, Assign, Block, Call, Const, Id, Literal, Member, Program, Return, Statement,
   generate
 } = require('../lib/ast');
-const defuns = parseKernel();
 const { formatDuration, formatGrid, measure } = require('./utils');
 
 const render = async => {
@@ -20,7 +19,7 @@ const render = async => {
       Block,
       ...defuns.map(construct),
       Assign(Id('$'), Call(Call(Id('require'), [Literal('../lib/overrides')]), [Id('$')])),
-      assemble(Statement, construct([s`shen.initialize`])));
+      assemble(Statement, construct([s`shen.initialise`])));
     return generate(
       Program([Statement(Assign(
         Member(Id('module'), Id('exports')),
@@ -48,6 +47,11 @@ const render = async => {
 
   return { size: syntax.length, duration: measureRender.duration };
 };
+
+console.log('- parsing kernel...');
+const { duration: parseDuration, result: defuns } = measure(parseKernel);
+console.log(`  parsed in ${formatDuration(parseDuration)}`);
+console.log();
 
 const sync = render(false);
 const async = render(true);

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -5,13 +5,13 @@ const {
   Arrow, Assign, Block, Call, Const, Id, Literal, Member, Program, Return, Statement,
   generate
 } = require('../lib/ast');
-const { defuns, statements } = parseKernel();
+const defuns = parseKernel();
 const { formatDuration, formatGrid, measure } = require('./utils');
 
 const render = async => {
   console.log(`- creating backend in ${async ? 'async' : 'sync'} mode...`);
   const measureBackend = measure(() => backend({ async }));
-  const { assemble, construct } = measureBackend.result;
+  const { assemble, construct, s } = measureBackend.result;
   console.log(`  created in ${formatDuration(measureBackend.duration)}`);
 
   console.log('- rendering kernel...');
@@ -20,7 +20,7 @@ const render = async => {
       Block,
       ...defuns.map(construct),
       Assign(Id('$'), Call(Call(Id('require'), [Literal('../lib/overrides')]), [Id('$')])),
-      ...statements.map(construct));
+      assemble(Statement, construct([s`shen.initialize`])));
     return generate(
       Program([Statement(Assign(
         Member(Id('module'), Id('exports')),

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -7,7 +7,7 @@ const {
 } = require('../lib/ast');
 const { formatDuration, formatGrid, measure } = require('./utils');
 
-const render = async => {
+const render = (async, defuns) => {
   console.log(`- creating backend in ${async ? 'async' : 'sync'} mode...`);
   const measureBackend = measure(() => backend({ async }));
   const { assemble, construct, s } = measureBackend.result;
@@ -49,12 +49,12 @@ const render = async => {
 };
 
 console.log('- parsing kernel...');
-const { duration: parseDuration, result: defuns } = measure(parseKernel);
-console.log(`  parsed in ${formatDuration(parseDuration)}`);
+const measureParse = measure(parseKernel);
+console.log(`  parsed in ${formatDuration(measureParse.duration)}`);
 console.log();
 
-const sync = render(false);
-const async = render(true);
+const sync = render(false, measureParse.result);
+const async = render(true, measureParse.result);
 const total = {
   size: sync.size + async.size,
   duration: sync.duration + async.duration

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -43,5 +43,5 @@ const OutStream = class {
     stoutput: new OutStream(process.stdout, 'stoutput'),
     sterror:  new OutStream(process.stderr, 'sterror')
   })));
-  await evalShen([s`shen.shen`]);
+  await evalShen([s`shen.repl`]);
 })();

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -32,7 +32,7 @@ const OutStream = class {
 };
 
 (async () => {
-  const { evalShen, s } = frontend(await kernel(backend({
+  const { caller, toList } = frontend(await kernel(backend({
     ...config,
     async: true,
     InStream,
@@ -43,5 +43,5 @@ const OutStream = class {
     stoutput: new OutStream(process.stdout, 'stoutput'),
     sterror:  new OutStream(process.stderr, 'sterror')
   })));
-  await evalShen([s`shen.repl`]);
+  await caller('shen.x.launcher.main')(toList(['shen', 'repl']));
 })();


### PR DESCRIPTION
- [x] New version of kernel, load `init.kl`, call `shen.initialise`.
- [x] Include `feature-expand` and provide feature symbols.
- [x] Use `launcher` extension in `npm run repl`.